### PR TITLE
Update EIP-7904 Glamsterdam status

### DIFF
--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -23,6 +23,11 @@
           "status": "Considered",
           "call": "acde/226",
           "date": "2025-12-18"
+        },
+        {
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ],
       "champions": [
@@ -30,13 +35,7 @@
           "name": "Maria Silva",
           "discord": "misilva73"
         }
-      ],
-      "notice": {
-        "title": "Likely not included in Glamsterdam",
-        "text": "This EIP is very likely to be dropped from Glamsterdam. The formal EIP status has not changed yet, pending a final decision.",
-        "call": "acde/237",
-        "timestamp": 1189
-      }
+      ]
     }
   ],
   "laymanDescription": "Updates gas costs of all compute operatons to ensure they accurately reflect their computational workload.",

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -23,11 +23,6 @@
           "status": "Considered",
           "call": "acde/226",
           "date": "2025-12-18"
-        },
-        {
-          "status": "Declined",
-          "call": null,
-          "date": null
         }
       ],
       "champions": [
@@ -35,7 +30,13 @@
           "name": "Maria Silva",
           "discord": "misilva73"
         }
-      ]
+      ],
+      "notice": {
+        "title": "Likely not included in Glamsterdam",
+        "text": "This EIP is very likely to be dropped from Glamsterdam. The formal EIP status has not changed yet, pending a final decision.",
+        "call": "acde/237",
+        "timestamp": 1189
+      }
     }
   ],
   "laymanDescription": "Updates gas costs of all compute operatons to ensure they accurately reflect their computational workload.",

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -23,6 +23,11 @@
           "status": "Considered",
           "call": "acde/226",
           "date": "2025-12-18"
+        },
+        {
+          "status": "Withdrawn",
+          "call": null,
+          "date": null
         }
       ],
       "champions": [
@@ -30,13 +35,7 @@
           "name": "Maria Silva",
           "discord": "misilva73"
         }
-      ],
-      "notice": {
-        "title": "Likely not included in Glamsterdam",
-        "text": "This EIP is very likely to be dropped from Glamsterdam. The formal EIP status has not changed yet, pending a final decision.",
-        "call": "acde/237",
-        "timestamp": 1189
-      }
+      ]
     }
   ],
   "laymanDescription": "Updates gas costs of all compute operatons to ensure they accurately reflect their computational workload.",


### PR DESCRIPTION
## Summary

Marks EIP-7904 as withdrawn from Glamsterdam in Forkcast and removes the temporary uncertainty notice from the EIP page.

## Details

This uses Forkcast's per-fork `Withdrawn` status rather than `Declined`, because the corresponding EIP-7773 update removes EIP-7904 from the Considered for Inclusion list without adding it to Declined for Inclusion. That better matches a proposal being dropped from the fork process rather than formally DFI'd by client teams.

This should wait on the EIP-7773 metadata update: https://github.com/ethereum/EIPs/pull/11795

## Validation

- `npm run validate-eips -- -f Glamsterdam`
- `npm run check`