### PR TITLE
[codex] Refine EIP fork timeline model

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -90,8 +90,10 @@
           "type": "array",
           "items": { "$ref": "#/$defs/StatusHistoryEntry" }
         },
-        "isHeadliner": { "type": "boolean" },
-        "wasHeadlinerCandidate": { "type": "boolean" },
+        "headlinerHistory": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/HeadlinerHistoryEntry" }
+        },
         "notice": {
           "type": "object",
           "required": ["title", "text"],
@@ -115,33 +117,20 @@
           "minItems": 1,
           "maxItems": 2
         },
-        "presentationHistory": {
+        "discussionHistory": {
           "type": "array",
-          "items": { "$ref": "#/$defs/PresentationHistoryEntry" }
+          "items": { "$ref": "#/$defs/DiscussionHistoryEntry" }
         }
       }
     },
-    "PresentationHistoryEntry": {
+    "DiscussionHistoryEntry": {
       "type": "object",
-      "required": ["type", "date"],
+      "required": ["call", "date"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "headliner_proposal",
-            "headliner_presentation",
-            "presentation",
-            "debate"
-          ],
-          "description": "Type of presentation event: headliner_proposal (forum post), headliner_presentation (initial call), presentation (regular call), debate (follow-up discussion)"
-        },
         "call": {
           "type": "string",
           "pattern": "^(acdc|acde|acdt)/[0-9]+$"
-        },
-        "link": {
-          "type": "string"
         },
         "date": {
           "type": "string",
@@ -151,23 +140,62 @@
           "type": "integer",
           "description": "Seconds into the call recording video"
         }
-      },
-      "allOf": [
+      }
+    },
+    "HeadlinerHistoryEntry": {
+      "oneOf": [
         {
-          "if": {
-            "properties": { "type": { "const": "headliner_proposal" } }
-          },
-          "then": { "required": ["link"] }
+          "type": "object",
+          "required": ["type", "link", "date"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "proposed" },
+            "link": { "type": "string" },
+            "date": {
+              "type": "string",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          }
         },
         {
-          "if": {
-            "properties": {
-              "type": {
-                "enum": ["headliner_presentation", "presentation", "debate"]
-              }
+          "type": "object",
+          "required": ["type", "call", "date"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "presented" },
+            "call": {
+              "type": "string",
+              "pattern": "^(acdc|acde|acdt)/[0-9]+$"
+            },
+            "date": {
+              "type": "string",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Seconds into the call recording video"
             }
-          },
-          "then": { "required": ["call"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "withdrawn" },
+            "call": {
+              "type": "string",
+              "pattern": "^(acdc|acde|acdt)/[0-9]+$"
+            },
+            "date": {
+              "type": "string",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Seconds into the call recording video"
+            }
+          }
         }
       ]
     },

--- a/scripts/generate-plan-artifacts.mjs
+++ b/scripts/generate-plan-artifacts.mjs
@@ -449,7 +449,7 @@ function loadInScopeEips(callType) {
     for (const fr of eip.forkRelationships || []) {
       const hasActiveStatus = fr.statusHistory?.length > 0 &&
         ['Proposed', 'Considered'].includes(fr.statusHistory[fr.statusHistory.length - 1].status);
-      const isCandidate = fr.isHeadliner || fr.wasHeadlinerCandidate;
+      const isCandidate = Boolean(fr.headlinerHistory?.length);
 
       if (hasActiveStatus || isCandidate) {
         const latestStatus = fr.statusHistory?.length > 0

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -412,7 +412,7 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
         : ['Included', 'Scheduled for Inclusion', 'Considered for Inclusion', 'Proposed for Inclusion', 'Declined for Inclusion']
       ).flatMap(stage => {
           // For Glamsterdam, exclude unselected headliner candidates from stage sections since they have their own section
-          // Selected headliners (isHeadliner=true) should still appear in their respective stages
+          // Selected headliners should still appear in their respective stages
           let stageEips = eips.filter(eip => {
             const matchesStage = getInclusionStage(eip, forkName) === stage;
             if (forkName.toLowerCase() === 'glamsterdam') {

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -10,6 +10,7 @@ import { upcomingCalls } from '../../domain/calls/upcomingCalls';
 import { onOpenCallSearch } from '../../domain/calls/callSearch';
 import { eipsData } from '../../data/eips';
 import { EIP, ForkRelationship, KeyDecision } from '../../types/eip';
+import { isHeadliner } from '../../utils/eip';
 import { isSearchHotkey } from '../search/searchShortcuts';
 
 // Mapping of breakout call types to their associated EIP IDs
@@ -1174,7 +1175,7 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
                   </Link>
                   {!isWorkspaceView && breakoutEipInfo.latestFork && (
                     <span className="text-slate-500 dark:text-slate-400">
-                      ({breakoutEipInfo.latestFork.statusHistory[breakoutEipInfo.latestFork.statusHistory.length - 1]?.status} for {breakoutEipInfo.latestFork.forkName}{breakoutEipInfo.latestFork.isHeadliner ? ', Headliner' : ''})
+                      ({breakoutEipInfo.latestFork.statusHistory[breakoutEipInfo.latestFork.statusHistory.length - 1]?.status} for {breakoutEipInfo.latestFork.forkName}{isHeadliner(breakoutEipInfo.eip, breakoutEipInfo.latestFork.forkName) ? ', Headliner' : ''})
                     </span>
                   )}
                 </div>

--- a/src/components/call/CallPlanPage.tsx
+++ b/src/components/call/CallPlanPage.tsx
@@ -7,6 +7,7 @@ import { networkUpgrades } from '../../data/upgrades';
 import { getPendingProposalsForFork, type PendingProposal } from '../../data/pending-proposals';
 import { fetchUpcomingCalls, type UpcomingCall } from '../../domain/calls/upcomingCalls';
 import { formatCallReference } from '../../domain/calls/callReference';
+import { getLatestHeadlinerCall } from '../../domain/eips/headlinerHistory';
 import { StructuredDecisionContent, EipLinkWithTooltip, DecisionTextWithEipLinks } from './KeyDecisionsSection';
 
 interface TldrData {
@@ -226,15 +227,16 @@ const CallPlanPage: React.FC = () => {
             lastDiscussedDate: latest.date,
             lastDiscussedCall: latest.call,
           });
-        } else if ((fr.isHeadliner || fr.wasHeadlinerCandidate) && upgrade.status === 'Planning') {
+        } else if (fr.headlinerHistory?.length && upgrade.status === 'Planning') {
           // Headliner candidates without formal PFI/CFI status
-          const lastPresentation = fr.presentationHistory?.[fr.presentationHistory.length - 1];
+          const lastHeadlinerCall = getLatestHeadlinerCall(fr);
+          const lastDiscussion = fr.discussionHistory?.[fr.discussionHistory.length - 1];
           eips.push({
             eip,
             forkName: forkDisplayName,
             currentStatus: 'Candidate',
-            lastDiscussedDate: lastPresentation?.date ?? null,
-            lastDiscussedCall: lastPresentation?.call ?? null,
+            lastDiscussedDate: lastDiscussion?.date ?? lastHeadlinerCall?.date ?? null,
+            lastDiscussedCall: lastDiscussion?.call ?? lastHeadlinerCall?.call ?? null,
           });
         }
       }

--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -1,28 +1,13 @@
 import React from 'react';
 import { Link } from '../navigation';
 import { EIP } from '../../types';
-import { networkUpgrades, getUpgradePagePath } from '../../data/upgrades';
+import { networkUpgrades, getUpgradeById, getUpgradePagePath } from '../../data/upgrades';
 import { formatCallReference } from '../../domain/calls/callReference';
+import { buildEipTimelineForkGroup } from '../../domain/eips/eipTimeline';
 import { Tooltip } from '../ui';
 
 interface EipTimelineProps {
   eip: EIP;
-}
-
-interface StatusEntry {
-  status: string;
-  date?: string | null;
-  call?: string | null;
-  timestamp?: number;
-  isCurrentStatus: boolean;
-}
-
-interface PresentationEntry {
-  type: 'headliner_proposal' | 'headliner_presentation' | 'presentation' | 'debate';
-  date?: string | null;
-  call?: string | null;
-  link?: string;
-  timestamp?: number;
 }
 
 const getForkDisplayName = (forkName: string): string => {
@@ -37,8 +22,7 @@ interface ForkGroup {
   champions?: { name: string }[];
   currentStatus: string;
   isHeadliner: boolean;
-  statusHistory: StatusEntry[];
-  presentations: PresentationEntry[];
+  items: ReturnType<typeof buildEipTimelineForkGroup>['items'];
 }
 
 const statusColors: Record<string, { dot: string; text: string }> = {
@@ -101,53 +85,12 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
     return getUpgradeOrder(b.forkName) - getUpgradeOrder(a.forkName);
   });
 
-  const forkGroups: ForkGroup[] = sortedForks.map((fork) => {
-    // If there are champions and no "Proposed" in history, prepend it
-    const hasProposedStep = fork.statusHistory.some(entry => entry.status === 'Proposed');
-    const hasChampions = fork.champions && fork.champions.length > 0 && fork.champions.some(c => c.name);
-    const effectiveHistory = (hasChampions && !hasProposedStep)
-      ? [{ status: 'Proposed' as const, call: null, date: null }, ...fork.statusHistory]
-      : fork.statusHistory;
-
-    // Reverse so most recent is first
-    const reversedHistory = [...effectiveHistory].reverse();
-    const currentStatus = reversedHistory[0]?.status || 'Proposed';
-
-    // Build status entries (include current status as first item)
-    const statusHistory: StatusEntry[] = reversedHistory
-      .map((entry, index) => ({
-        status: entry.status,
-        date: entry.date,
-        call: entry.call,
-        timestamp: entry.timestamp,
-        isCurrentStatus: index === 0,
-      }))
-      .filter((entry) => {
-        // Always show current status
-        if (entry.isCurrentStatus) return true;
-        const hasAttribution = entry.date || entry.call;
-        const isProposed = entry.status === 'Proposed';
-        return hasAttribution || isProposed;
-      });
-
-    // Build presentation entries
-    const presentations: PresentationEntry[] = (fork.presentationHistory || []).map(p => ({
-      type: p.type,
-      date: p.date,
-      call: p.call,
-      link: p.link,
-      timestamp: p.timestamp,
-    }));
-
-    return {
-      forkName: fork.forkName,
-      champions: fork.champions,
-      currentStatus,
-      isHeadliner: !!fork.isHeadliner,
-      statusHistory,
-      presentations,
-    };
-  });
+  const forkGroups: ForkGroup[] = sortedForks.map((fork) =>
+    buildEipTimelineForkGroup(fork, {
+      eipId: eip.id,
+      headlinerSelection: getUpgradeById(fork.forkName.toLowerCase())?.headlinerSelection,
+    })
+  );
 
   const hasCreatedDate = !!eip.createdDate;
   const totalNodes = forkGroups.length + (hasCreatedDate ? 1 : 0);
@@ -169,30 +112,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
               const visibleChampions = group.champions?.filter(c => c.name) ?? [];
               const hasVisibleChampions = visibleChampions.length > 0;
 
-              // Merge and sort status history and presentations chronologically
-              const allItems = [
-                ...group.statusHistory.map((entry) => ({
-                  type: 'status' as const,
-                  entry,
-                  date: entry.date,
-                  isCurrentStatus: entry.isCurrentStatus
-                })),
-                ...group.presentations.map((presentation) => ({
-                  type: 'presentation' as const,
-                  presentation,
-                  date: presentation.date
-                })),
-              ].sort((a, b) => {
-                // Current status always first
-                if (a.type === 'status' && a.isCurrentStatus) return -1;
-                if (b.type === 'status' && b.isCurrentStatus) return 1;
-
-                // Then sort by date (most recent first)
-                if (!a.date && !b.date) return 0;
-                if (!a.date) return 1;
-                if (!b.date) return -1;
-                return new Date(b.date).getTime() - new Date(a.date).getTime();
-              });
+              const allItems = group.items;
 
               return (
                 <div key={group.forkName} className="relative flex gap-2.5 sm:gap-3">
@@ -243,7 +163,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                           const isLastChild = idx === allItems.length - 1;
 
                           if (item.type === 'status') {
-                            const entry = item.entry;
+                            const entry = item;
                             const entryColors = statusColors[entry.status] || statusColors.Proposed;
                             return (
                               <div key={`status-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
@@ -299,16 +219,16 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                               </div>
                             );
                           } else {
-                            const presentation = item.presentation;
+                            const event = item;
                             const label = {
-                              'headliner_proposal': 'Headliner Proposal',
-                              'headliner_presentation': 'Headliner Presentation',
-                              'presentation': 'Presented',
-                              'debate': 'Debated',
-                            }[presentation.type] || 'Presented';
+                              headlinerProposed: 'Headliner Proposed',
+                              headlinerPresented: 'Headliner Presented',
+                              headlinerWithdrawn: 'Headliner Withdrawn',
+                              discussion: 'Discussion',
+                            }[event.kind];
 
                             return (
-                              <div key={`pres-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
+                              <div key={`event-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
                                 <div className="relative mt-1 w-2 shrink-0 self-stretch">
                                   <div className="relative z-10 w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />
                                   {!isLastChild && (
@@ -319,14 +239,14 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                                   <span className="text-xs text-slate-500 dark:text-slate-400">
                                     {label}
                                   </span>
-                                  {(presentation.date || presentation.call || presentation.link) && (
+                                  {(event.date || event.call || event.link) && (
                                     <>
                                       <span className="hidden md:inline text-xs text-slate-400 dark:text-slate-400">
                                         {' · '}
-                                        {presentation.date && formatDate(presentation.date)}
-                                        {presentation.date && (presentation.call || presentation.link) && ' · '}
-                                        {presentation.call && (() => {
-                                          const { display, link } = formatCallReference(presentation.call, presentation.timestamp);
+                                        {event.date && formatDate(event.date)}
+                                        {event.date && (event.call || event.link) && ' · '}
+                                        {event.call && (() => {
+                                          const { display, link } = formatCallReference(event.call, event.timestamp);
                                           return (
                                             <Link
                                               to={link}
@@ -336,9 +256,9 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                                             </Link>
                                           );
                                         })()}
-                                        {!presentation.call && presentation.link && (
+                                        {!event.call && event.link && (
                                           <a
-                                            href={presentation.link}
+                                            href={event.link}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             className="hover:text-purple-600 dark:hover:text-purple-400 underline decoration-slate-300 dark:decoration-slate-600 underline-offset-2 inline-flex items-center gap-1"
@@ -351,10 +271,10 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                                         )}
                                       </span>
                                       <div className="md:hidden text-xs text-slate-400 dark:text-slate-400">
-                                        {presentation.date && formatDate(presentation.date)}
-                                        {presentation.date && (presentation.call || presentation.link) && ' · '}
-                                        {presentation.call && (() => {
-                                          const { display, link } = formatCallReference(presentation.call, presentation.timestamp);
+                                        {event.date && formatDate(event.date)}
+                                        {event.date && (event.call || event.link) && ' · '}
+                                        {event.call && (() => {
+                                          const { display, link } = formatCallReference(event.call, event.timestamp);
                                           return (
                                             <Link
                                               to={link}
@@ -364,9 +284,9 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                                             </Link>
                                           );
                                         })()}
-                                        {!presentation.call && presentation.link && (
+                                        {!event.call && event.link && (
                                           <a
-                                            href={presentation.link}
+                                            href={event.link}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             className="hover:text-purple-600 dark:hover:text-purple-400 underline decoration-slate-300 dark:decoration-slate-600 underline-offset-2 inline-flex items-center gap-1"

--- a/src/data/eips/4758.json
+++ b/src/data/eips/4758.json
@@ -20,9 +20,8 @@
           "timestamp": 4148
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acde/237",
           "date": "2026-05-21",
           "timestamp": 3352

--- a/src/data/eips/7594.json
+++ b/src/data/eips/7594.json
@@ -18,8 +18,7 @@
           "call": null,
           "date": null
         }
-      ],
-      "isHeadliner": true
+      ]
     }
   ],
   "laymanDescription": "PeerDAS enables Ethereum nodes to specialize in storing different pieces of data while still verifying everything is available. This foundational change dramatically increases data capacity for Layer 2 networks while maintaining security.",

--- a/src/data/eips/7692.json
+++ b/src/data/eips/7692.json
@@ -29,13 +29,11 @@
           "date": "2025-08-14"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464",
-          "date": "2025-06-05"
+          "type": "proposed",
+          "date": "2025-06-05",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464"
         }
       ]
     }

--- a/src/data/eips/7709.json
+++ b/src/data/eips/7709.json
@@ -21,10 +21,8 @@
           "timestamp": 4379
         }
       ],
-      "isHeadliner": false,
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acde/236",
           "date": "2026-05-07",
           "timestamp": 4356

--- a/src/data/eips/7716.json
+++ b/src/data/eips/7716.json
@@ -20,9 +20,8 @@
           "timestamp": 3532
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acdc/177",
           "date": "2026-04-16",
           "timestamp": 3532

--- a/src/data/eips/7732.json
+++ b/src/data/eips/7732.json
@@ -30,24 +30,22 @@
           "date": null
         }
       ],
-      "isHeadliner": true,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/eip-7732-the-case-for-inclusion-in-glamsterdam/24306",
-          "date": "2025-05-22"
-        },
-        {
-          "date": "2025-05-29",
-          "type": "headliner_presentation",
-          "call": "acdc/158"
-        }
-      ],
       "champions": [
         {
           "name": "potuz",
           "discord": "potuz"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2025-05-22",
+          "link": "https://ethereum-magicians.org/t/eip-7732-the-case-for-inclusion-in-glamsterdam/24306"
+        },
+        {
+          "type": "presented",
+          "date": "2025-05-29",
+          "call": "acdc/158"
         }
       ]
     }
@@ -98,8 +96,17 @@
   ],
   "tradeoffs": null,
   "supportingDocuments": [
-    { "label": "Gloas Annotated: Beacon-Chain", "url": "https://www.potuz.net/posts/gloas-annotated-1/" },
-    { "label": "Gloas Annotated: Gossip", "url": "https://www.potuz.net/posts/gloas-annotated-pubsub/" },
-    { "label": "Gloas Annotated: Forkchoice", "url": "https://www.potuz.net/posts/gloas-annotated-forkchoice/" }
+    {
+      "label": "Gloas Annotated: Beacon-Chain",
+      "url": "https://www.potuz.net/posts/gloas-annotated-1/"
+    },
+    {
+      "label": "Gloas Annotated: Gossip",
+      "url": "https://www.potuz.net/posts/gloas-annotated-pubsub/"
+    },
+    {
+      "label": "Gloas Annotated: Forkchoice",
+      "url": "https://www.potuz.net/posts/gloas-annotated-forkchoice/"
+    }
   ]
 }

--- a/src/data/eips/7782.json
+++ b/src/data/eips/7782.json
@@ -20,17 +20,15 @@
           "date": "2025-08-14"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/eip-7782-the-case-for-2x-shorter-slot-times-in-glamsterdam/24616",
-          "date": "2025-06-20"
+          "type": "proposed",
+          "date": "2025-06-20",
+          "link": "https://ethereum-magicians.org/t/eip-7782-the-case-for-2x-shorter-slot-times-in-glamsterdam/24616"
         },
         {
+          "type": "presented",
           "date": "2025-06-26",
-          "type": "headliner_presentation",
           "call": "acdc/159"
         }
       ]

--- a/src/data/eips/7805.json
+++ b/src/data/eips/7805.json
@@ -25,24 +25,22 @@
           "date": "2025-12-11"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/eip-7805-fork-choice-inclusion-lists-focil-as-a-candidate-for-glamsterdam/24342",
-          "date": "2025-05-26"
-        },
-        {
-          "date": "2025-05-29",
-          "type": "headliner_presentation",
-          "call": "acdc/158"
-        }
-      ],
       "champions": [
         {
           "name": "soispoke",
           "discord": "soispoke"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2025-05-26",
+          "link": "https://ethereum-magicians.org/t/eip-7805-fork-choice-inclusion-lists-focil-as-a-candidate-for-glamsterdam/24342"
+        },
+        {
+          "type": "presented",
+          "date": "2025-05-29",
+          "call": "acdc/158"
         }
       ]
     },
@@ -60,24 +58,22 @@
           "date": "2026-02-19"
         }
       ],
-      "isHeadliner": true,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-focil-eip-7805/27604",
-          "date": "2026-01-27"
-        },
-        {
-          "type": "headliner_presentation",
-          "call": "acdc/174",
-          "date": "2026-02-05"
-        }
-      ],
       "champions": [
         {
           "name": "soispoke",
           "discord": "soispoke"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2026-01-27",
+          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-focil-eip-7805/27604"
+        },
+        {
+          "type": "presented",
+          "date": "2026-02-05",
+          "call": "acdc/174"
         }
       ]
     }

--- a/src/data/eips/7807.json
+++ b/src/data/eips/7807.json
@@ -20,24 +20,22 @@
           "date": "2026-03-12"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-ssz-execution-blocks/27619",
-          "date": "2026-01-29"
-        },
-        {
-          "type": "headliner_presentation",
-          "call": "acde/229",
-          "date": "2026-01-29"
-        }
-      ],
       "champions": [
         {
           "name": "Etan Kissling",
           "discord": "etan-status"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2026-01-29",
+          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-ssz-execution-blocks/27619"
+        },
+        {
+          "type": "presented",
+          "date": "2026-01-29",
+          "call": "acde/229"
         }
       ]
     }

--- a/src/data/eips/7886.json
+++ b/src/data/eips/7886.json
@@ -20,13 +20,11 @@
           "date": "2025-08-14"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500",
-          "date": "2025-06-09"
+          "type": "proposed",
+          "date": "2025-06-09",
+          "link": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500"
         }
       ]
     }

--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -29,24 +29,22 @@
           "date": null
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-pureth/24459",
-          "date": "2025-06-05"
-        },
-        {
-          "date": "2025-06-19",
-          "type": "headliner_presentation",
-          "call": "acde/214"
-        }
-      ],
       "champions": [
         {
           "name": "Etan Kissling",
           "discord": "etan_status"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2025-06-05",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-pureth/24459"
+        },
+        {
+          "type": "presented",
+          "date": "2025-06-19",
+          "call": "acde/214"
         }
       ]
     }

--- a/src/data/eips/7928.json
+++ b/src/data/eips/7928.json
@@ -20,24 +20,22 @@
           "date": null
         }
       ],
-      "isHeadliner": true,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
-        {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/eip-7928-block-level-access-lists-the-case-for-glamsterdam/24343",
-          "date": "2025-05-26"
-        },
-        {
-          "date": "2025-06-05",
-          "type": "headliner_presentation",
-          "call": "acde/213"
-        }
-      ],
       "champions": [
         {
           "name": "Toni Wahrstätter",
           "discord": "nero_eth"
+        }
+      ],
+      "headlinerHistory": [
+        {
+          "type": "proposed",
+          "date": "2025-05-26",
+          "link": "https://ethereum-magicians.org/t/eip-7928-block-level-access-lists-the-case-for-glamsterdam/24343"
+        },
+        {
+          "type": "presented",
+          "date": "2025-06-05",
+          "call": "acde/213"
         }
       ]
     }
@@ -85,6 +83,9 @@
   ],
   "tradeoffs": null,
   "supportingDocuments": [
-    { "label": "blockaccesslist.xyz", "url": "https://blockaccesslist.xyz" }
+    {
+      "label": "blockaccesslist.xyz",
+      "url": "https://blockaccesslist.xyz"
+    }
   ]
 }

--- a/src/data/eips/7937.json
+++ b/src/data/eips/7937.json
@@ -20,17 +20,15 @@
           "date": "2025-08-14"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-evm64/24311",
-          "date": "2025-05-22"
+          "type": "proposed",
+          "date": "2025-05-22",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-evm64/24311"
         },
         {
+          "type": "presented",
           "date": "2025-06-05",
-          "type": "headliner_presentation",
           "call": "acde/213"
         }
       ]

--- a/src/data/eips/7942.json
+++ b/src/data/eips/7942.json
@@ -20,17 +20,15 @@
           "date": "2025-08-14"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-available-attestation/24377",
-          "date": "2025-05-29"
+          "type": "proposed",
+          "date": "2025-05-29",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-available-attestation/24377"
         },
         {
+          "type": "presented",
           "date": "2025-06-05",
-          "type": "headliner_presentation",
           "call": "acde/213"
         }
       ]

--- a/src/data/eips/8025.json
+++ b/src/data/eips/8025.json
@@ -63,9 +63,8 @@
           "timestamp": 4125
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acdc/178",
           "date": "2026-05-14",
           "timestamp": 4125

--- a/src/data/eips/8105.json
+++ b/src/data/eips/8105.json
@@ -25,24 +25,22 @@
           "date": "2026-02-23"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
       "champions": [
         {
           "name": "Jannik Luhn",
           "discord": "jannik031153"
         }
       ],
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-eip-8105-universal-enshrined-encrypted-mempool-eem/27448",
-          "date": "2026-01-16"
+          "type": "proposed",
+          "date": "2026-01-16",
+          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-eip-8105-universal-enshrined-encrypted-mempool-eem/27448"
         },
         {
-          "type": "headliner_presentation",
-          "call": "acde/229",
-          "date": "2026-01-29"
+          "type": "presented",
+          "date": "2026-01-29",
+          "call": "acde/229"
         }
       ]
     }

--- a/src/data/eips/8141.json
+++ b/src/data/eips/8141.json
@@ -21,8 +21,6 @@
           "timestamp": 5871
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
       "champions": [
         {
           "name": "Felix Lange",
@@ -33,16 +31,16 @@
           "discord": "lightclient"
         }
       ],
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-frame-transaction/27618",
-          "date": "2026-01-29"
+          "type": "proposed",
+          "date": "2026-01-29",
+          "link": "https://ethereum-magicians.org/t/hegota-headliner-proposal-frame-transaction/27618"
         },
         {
-          "type": "headliner_presentation",
-          "call": "acde/229",
-          "date": "2026-01-29"
+          "type": "presented",
+          "date": "2026-01-29",
+          "call": "acde/229"
         }
       ]
     }

--- a/src/data/eips/8148.json
+++ b/src/data/eips/8148.json
@@ -20,9 +20,8 @@
           "timestamp": 2068
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acdc/179",
           "date": "2026-05-28",
           "timestamp": 2068

--- a/src/data/eips/8182.json
+++ b/src/data/eips/8182.json
@@ -21,9 +21,8 @@
           "timestamp": 2172
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acde/237",
           "date": "2026-05-21",
           "timestamp": 2172

--- a/src/data/eips/8184.json
+++ b/src/data/eips/8184.json
@@ -25,24 +25,22 @@
           "date": "2026-03-12"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": true,
       "champions": [
         {
           "name": "Justin Florentine",
           "discord": "robocopsgonemad"
         }
       ],
-      "presentationHistory": [
+      "headlinerHistory": [
         {
-          "type": "headliner_proposal",
-          "link": "https://ethereum-magicians.org/t/hegota-headliner-lucid-encrypted-mempool/27658",
-          "date": "2026-02-05"
+          "type": "proposed",
+          "date": "2026-02-05",
+          "link": "https://ethereum-magicians.org/t/hegota-headliner-lucid-encrypted-mempool/27658"
         },
         {
-          "type": "headliner_presentation",
-          "call": "acde/230",
-          "date": "2026-02-12"
+          "type": "presented",
+          "date": "2026-02-12",
+          "call": "acde/230"
         }
       ]
     }

--- a/src/data/eips/8188.json
+++ b/src/data/eips/8188.json
@@ -20,9 +20,8 @@
           "timestamp": 1269
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acde/237",
           "date": "2026-05-21",
           "timestamp": 1269

--- a/src/data/eips/8205.json
+++ b/src/data/eips/8205.json
@@ -20,9 +20,8 @@
           "timestamp": 3853
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acdc/177",
           "date": "2026-04-16",
           "timestamp": 3853

--- a/src/data/eips/8253.json
+++ b/src/data/eips/8253.json
@@ -19,9 +19,8 @@
           "timestamp": 4879
         }
       ],
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acde/236",
           "date": "2026-05-07",
           "timestamp": 4879

--- a/src/data/eips/8282.json
+++ b/src/data/eips/8282.json
@@ -28,16 +28,12 @@
           "date": "2026-06-18"
         }
       ],
-      "isHeadliner": false,
-      "wasHeadlinerCandidate": false,
-      "presentationHistory": [
+      "discussionHistory": [
         {
-          "type": "presentation",
           "call": "acdc/180",
           "date": "2026-06-11"
         },
         {
-          "type": "debate",
           "call": "acdt/83",
           "date": "2026-06-15"
         }

--- a/src/data/upgrades.test.ts
+++ b/src/data/upgrades.test.ts
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import type { EIP } from '../types';
+import { networkUpgrades } from './upgrades';
+import { HEADLINER_SELECTION_LAYERS, getSelectedHeadlinerIds } from '../domain/eips/headlinerSelection';
+
+const sourceEips = readdirSync('src/data/eips')
+  .filter((fileName) => fileName.endsWith('.json'))
+  .map((fileName) => JSON.parse(readFileSync(`src/data/eips/${fileName}`, 'utf8')) as EIP);
+
+const eipById = new Map(sourceEips.map((eip) => [eip.id, eip]));
+
+describe('networkUpgrades headliner selections', () => {
+  it('keeps selected headliners unique and aligned to layer slots when layer is known', () => {
+    for (const upgrade of networkUpgrades) {
+      const selectedIds = getSelectedHeadlinerIds(upgrade.headlinerSelection);
+      expect(new Set(selectedIds).size, upgrade.id).toBe(selectedIds.length);
+
+      for (const layer of HEADLINER_SELECTION_LAYERS) {
+        const selectedEipId = upgrade.headlinerSelection?.selected[layer];
+        if (selectedEipId === undefined) continue;
+
+        const eip = eipById.get(selectedEipId);
+        expect(eip, `${upgrade.id} ${layer} headliner ${selectedEipId}`).toBeDefined();
+        if (eip?.layer) {
+          expect(eip.layer, `${upgrade.id} ${layer} headliner ${selectedEipId}`).toBe(layer);
+        }
+      }
+    }
+  });
+});

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -1,4 +1,4 @@
-import { ClientTeamPerspective } from '../types/eip';
+import { ClientTeamPerspective, HeadlinerSelection } from '../types/eip';
 import type { MacroPhase } from '../types/timeline';
 
 export interface ActivationDetails {
@@ -23,6 +23,7 @@ export interface NetworkUpgrade {
   highlights?: string;
   externalLink?: string;
   hideProgressBar?: boolean;
+  headlinerSelection?: HeadlinerSelection;
 }
 
 export const networkUpgrades: NetworkUpgrade[] = [
@@ -99,6 +100,12 @@ export const networkUpgrades: NetworkUpgrade[] = [
     activationDate: 'Dec 3, 2025',
     disabled: false,
     highlights: 'PeerDAS (EIP-7594), gas limit increase, introduce BPOs',
+    headlinerSelection: {
+      status: 'finalized',
+      selected: {
+        CL: 7594
+      }
+    },
     activationDetails: {
       blockNumber: 23935694,
       epochNumber: 411392,
@@ -115,6 +122,13 @@ export const networkUpgrades: NetworkUpgrade[] = [
     activationDate: '2026',
     disabled: false,
     metaEipLink: 'https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-upgrade-meta-thread/21195',
+    headlinerSelection: {
+      status: 'finalized',
+      selected: {
+        EL: 7928,
+        CL: 7732
+      }
+    },
     clientTeamPerspectives: [
       {
         teamName: 'Besu',
@@ -194,7 +208,13 @@ export const networkUpgrades: NetworkUpgrade[] = [
     activationDate: '2027',
     disabled: false,
     macroPhaseOverride: 'scoping',
-    metaEipLink: 'https://ethereum-magicians.org/t/eip-8081-hegota-network-upgrade-meta-thread/26876'
+    metaEipLink: 'https://ethereum-magicians.org/t/eip-8081-hegota-network-upgrade-meta-thread/26876',
+    headlinerSelection: {
+      status: 'finalized',
+      selected: {
+        CL: 7805
+      }
+    }
   }
 ];
 

--- a/src/domain/eips/eipTimeline.test.ts
+++ b/src/domain/eips/eipTimeline.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { ForkRelationship } from '../../types/eip';
+import { buildEipTimelineForkGroup } from './eipTimeline';
+
+type StatusEntry = ForkRelationship['statusHistory'][number];
+type DiscussionEntry = NonNullable<ForkRelationship['discussionHistory']>[number];
+
+const status = (
+  statusValue: StatusEntry['status'],
+  date: string | null,
+  call: StatusEntry['call'] = null,
+  timestamp?: number,
+): StatusEntry => ({
+  status: statusValue,
+  date,
+  call,
+  timestamp,
+});
+
+const discussion = (
+  date: string,
+  values: Omit<DiscussionEntry, 'date'>,
+): DiscussionEntry => ({
+  date,
+  ...values,
+});
+
+const fork = (overrides: Partial<ForkRelationship>): ForkRelationship => ({
+  forkName: 'Glamsterdam',
+  statusHistory: [],
+  ...overrides,
+});
+
+describe('buildEipTimelineForkGroup', () => {
+  it('dedupes a discussion with the same call and date as a status item', () => {
+    const group = buildEipTimelineForkGroup(fork({
+      statusHistory: [status('Proposed', '2026-05-21', 'acde/237', 4148)],
+      discussionHistory: [
+        discussion('2026-05-21', { call: 'acde/237', timestamp: 3352 }),
+      ],
+    }));
+
+    expect(group.items).toEqual([
+      {
+        type: 'status',
+        status: 'Proposed',
+        date: '2026-05-21',
+        call: 'acde/237',
+        timestamp: 4148,
+        isCurrentStatus: true,
+      },
+    ]);
+  });
+
+  it('keeps independent discussion references without inventing status transitions', () => {
+    const group = buildEipTimelineForkGroup(fork({
+      statusHistory: [status('Considered', '2026-06-18', 'acde/239')],
+      discussionHistory: [
+        discussion('2026-06-11', { call: 'acdc/180' }),
+        discussion('2026-06-15', { call: 'acdt/83' }),
+      ],
+    }));
+
+    expect(group.items).toMatchObject([
+      { type: 'status', status: 'Considered', date: '2026-06-18', isCurrentStatus: true },
+      { type: 'event', kind: 'discussion', date: '2026-06-15', call: 'acdt/83' },
+      { type: 'event', kind: 'discussion', date: '2026-06-11', call: 'acdc/180' },
+    ]);
+  });
+
+  it('preserves headliner lifecycle context as standalone timeline items', () => {
+    const group = buildEipTimelineForkGroup(
+      fork({
+        statusHistory: [status('Scheduled', null)],
+        headlinerHistory: [
+          { type: 'proposed', link: 'https://example.com/forum', date: '2025-05-22' },
+          { type: 'presented', call: 'acdc/158', date: '2025-05-29' },
+        ],
+      }),
+      {
+        eipId: 7732,
+        headlinerSelection: {
+          status: 'finalized',
+          selected: { CL: 7732 },
+        },
+      },
+    );
+
+    expect(group.isHeadliner).toBe(true);
+    expect(group.items).toEqual([
+      {
+        type: 'status',
+        status: 'Scheduled',
+        date: null,
+        call: null,
+        timestamp: undefined,
+        isCurrentStatus: true,
+      },
+      {
+        type: 'event',
+        kind: 'headlinerPresented',
+        date: '2025-05-29',
+        call: 'acdc/158',
+        link: undefined,
+        timestamp: undefined,
+      },
+      {
+        type: 'event',
+        kind: 'headlinerProposed',
+        date: '2025-05-22',
+        call: undefined,
+        link: 'https://example.com/forum',
+        timestamp: undefined,
+      },
+    ]);
+  });
+
+  it('dedupes a headliner presentation with the same call and date as a status item', () => {
+    const group = buildEipTimelineForkGroup(fork({
+      statusHistory: [status('Proposed', '2026-02-12', 'acde/230')],
+      headlinerHistory: [
+        { type: 'proposed', link: 'https://example.com/forum', date: '2026-02-05' },
+        { type: 'presented', call: 'acde/230', date: '2026-02-12' },
+      ],
+    }));
+
+    expect(group.items).toMatchObject([
+      { type: 'status', status: 'Proposed', date: '2026-02-12', call: 'acde/230' },
+      { type: 'event', kind: 'headlinerProposed', date: '2026-02-05' },
+    ]);
+  });
+
+  it('keeps the champion-inferred Proposed item when no presentation exists', () => {
+    const group = buildEipTimelineForkGroup(fork({
+      statusHistory: [status('Considered', '2026-01-01')],
+      champions: [{ name: 'Ada' }],
+    }));
+
+    expect(group.items.map((item) =>
+      item.type === 'status' ? `${item.status}:${item.date ?? 'undated'}` : item.kind
+    )).toEqual(['Considered:2026-01-01', 'Proposed:undated']);
+  });
+});

--- a/src/domain/eips/eipTimeline.ts
+++ b/src/domain/eips/eipTimeline.ts
@@ -1,0 +1,169 @@
+import type { ForkRelationship } from '../../types/eip';
+import type { HeadlinerSelection } from '../../types/eip';
+import { isSelectedHeadlinerId } from './headlinerSelection';
+
+type StatusHistoryEntry = ForkRelationship['statusHistory'][number];
+type DiscussionHistoryEntry = NonNullable<ForkRelationship['discussionHistory']>[number];
+type HeadlinerHistoryEntry = NonNullable<ForkRelationship['headlinerHistory']>[number];
+type CallReference = StatusHistoryEntry['call'];
+type ForkStatus = StatusHistoryEntry['status'];
+
+export interface EipTimelineStatusItem {
+  type: 'status';
+  status: ForkStatus;
+  date: string | null;
+  call: CallReference;
+  timestamp?: number;
+  isCurrentStatus: boolean;
+}
+
+export type EipTimelineEventKind =
+  | 'discussion'
+  | 'headlinerProposed'
+  | 'headlinerPresented'
+  | 'headlinerWithdrawn';
+
+export interface EipTimelineEventItem {
+  type: 'event';
+  kind: EipTimelineEventKind;
+  date: string | null;
+  call?: DiscussionHistoryEntry['call'];
+  link?: string;
+  timestamp?: number;
+}
+
+export type EipTimelineItem = EipTimelineStatusItem | EipTimelineEventItem;
+
+export interface EipTimelineForkGroup {
+  forkName: string;
+  champions?: ForkRelationship['champions'];
+  currentStatus: ForkStatus;
+  isHeadliner: boolean;
+  items: EipTimelineItem[];
+}
+
+export interface BuildEipTimelineForkGroupOptions {
+  eipId?: number;
+  headlinerSelection?: HeadlinerSelection;
+}
+
+type MutableStatusEntry = {
+  status: ForkStatus;
+  date: string | null;
+  call: CallReference;
+  timestamp?: number;
+};
+
+const hasNamedChampion = (fork: ForkRelationship): boolean =>
+  Boolean(fork.champions?.some((champion) => champion.name));
+
+const buildEffectiveStatusHistory = (fork: ForkRelationship): MutableStatusEntry[] => {
+  const statusHistory = fork.statusHistory.map((entry) => ({ ...entry }));
+  const proposedEntries = statusHistory.filter((entry) => entry.status === 'Proposed');
+
+  if (proposedEntries.length === 0 && hasNamedChampion(fork)) {
+    return [{ status: 'Proposed', date: null, call: null }, ...statusHistory];
+  }
+
+  return statusHistory;
+};
+
+const shouldShowStatusItem = (item: EipTimelineStatusItem): boolean => {
+  if (item.isCurrentStatus) return true;
+  if (item.status === 'Proposed') return true;
+  return Boolean(item.date || item.call);
+};
+
+const getItemDate = (item: EipTimelineItem): string | null => item.date ?? null;
+
+const getReferenceKey = (entry: { call?: CallReference; date?: string | null }): string | null => {
+  if (!entry.call || !entry.date) return null;
+  return `${entry.call}|${entry.date}`;
+};
+
+const isDuplicateEvent = (
+  event: EipTimelineEventItem,
+  statusReferenceKeys: Set<string>,
+): boolean => {
+  if (event.kind !== 'discussion' && event.kind !== 'headlinerPresented') return false;
+  const key = getReferenceKey(event);
+  return key !== null && statusReferenceKeys.has(key);
+};
+
+const sortTimelineItems = (items: EipTimelineItem[]): EipTimelineItem[] =>
+  [...items].sort((a, b) => {
+    if (a.type === 'status' && a.isCurrentStatus) return -1;
+    if (b.type === 'status' && b.isCurrentStatus) return 1;
+
+    const aDate = getItemDate(a);
+    const bDate = getItemDate(b);
+    if (!aDate && !bDate) return 0;
+    if (!aDate) return 1;
+    if (!bDate) return -1;
+    return new Date(bDate).getTime() - new Date(aDate).getTime();
+  });
+
+const headlinerEventKindByType = {
+  proposed: 'headlinerProposed',
+  presented: 'headlinerPresented',
+  withdrawn: 'headlinerWithdrawn',
+} satisfies Record<HeadlinerHistoryEntry['type'], EipTimelineEventKind>;
+
+const getHeadlinerEventKind = (entry: HeadlinerHistoryEntry): EipTimelineEventKind =>
+  headlinerEventKindByType[entry.type];
+
+const buildHeadlinerEventItems = (
+  headlinerHistory: HeadlinerHistoryEntry[] = [],
+): EipTimelineEventItem[] =>
+  headlinerHistory.map((entry) => ({
+    type: 'event',
+    kind: getHeadlinerEventKind(entry),
+    date: entry.date ?? null,
+    call: 'call' in entry ? entry.call : undefined,
+    link: 'link' in entry ? entry.link : undefined,
+    timestamp: 'timestamp' in entry ? entry.timestamp : undefined,
+  }));
+
+export function buildEipTimelineForkGroup(
+  fork: ForkRelationship,
+  options: BuildEipTimelineForkGroupOptions = {},
+): EipTimelineForkGroup {
+  const effectiveHistory = buildEffectiveStatusHistory(fork);
+  const reversedHistory = [...effectiveHistory].reverse();
+  const currentStatus = reversedHistory[0]?.status ?? 'Proposed';
+
+  const statusItems: EipTimelineStatusItem[] = reversedHistory
+    .map((entry, index) => ({
+      type: 'status' as const,
+      status: entry.status,
+      date: entry.date,
+      call: entry.call,
+      timestamp: entry.timestamp,
+      isCurrentStatus: index === 0,
+    }))
+    .filter(shouldShowStatusItem);
+
+  const statusReferenceKeys = new Set(
+    statusItems.map(getReferenceKey).filter((key): key is string => key !== null)
+  );
+
+  const eventItems: EipTimelineEventItem[] = [
+    ...(fork.discussionHistory ?? []).map((discussion) => ({
+      type: 'event' as const,
+      kind: 'discussion' as const,
+      date: discussion.date,
+      call: discussion.call,
+      timestamp: discussion.timestamp,
+    })),
+    ...buildHeadlinerEventItems(fork.headlinerHistory),
+  ].filter((event) => !isDuplicateEvent(event, statusReferenceKeys));
+
+  return {
+    forkName: fork.forkName,
+    champions: fork.champions,
+    currentStatus,
+    isHeadliner: options.eipId !== undefined &&
+      isSelectedHeadlinerId(options.headlinerSelection, options.eipId),
+    items: sortTimelineItems([...statusItems, ...eventItems]),
+  };
+}

--- a/src/domain/eips/headlinerHistory.test.ts
+++ b/src/domain/eips/headlinerHistory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { ForkRelationship } from '../../types/eip';
+import {
+  getCurrentHeadlinerCandidacyState,
+  getLatestHeadlinerCall,
+  hasActiveHeadlinerCandidacy,
+} from './headlinerHistory';
+
+const fork = (headlinerHistory: ForkRelationship['headlinerHistory']): ForkRelationship => ({
+  forkName: 'Glamsterdam',
+  statusHistory: [],
+  headlinerHistory,
+});
+
+describe('headlinerHistory', () => {
+  it('derives active candidacy from the latest candidacy state', () => {
+    const withdrawnThenReproposed = fork([
+      { type: 'proposed', date: '2026-01-01', link: 'https://example.com/proposal' },
+      { type: 'withdrawn', date: '2026-01-15' },
+      { type: 'proposed', date: '2026-01-22', link: 'https://example.com/reproposal' },
+    ]);
+
+    expect(getCurrentHeadlinerCandidacyState(withdrawnThenReproposed)).toMatchObject({ type: 'proposed' });
+    expect(hasActiveHeadlinerCandidacy(withdrawnThenReproposed)).toBe(true);
+  });
+
+  it('finds the latest headliner event with a call reference', () => {
+    const relationship = fork([
+      { type: 'presented', date: '2026-01-08', call: 'acde/229' },
+      { type: 'withdrawn', date: '2026-01-15', call: 'acdc/174', timestamp: 120 },
+    ]);
+
+    expect(getLatestHeadlinerCall(relationship)).toEqual({
+      type: 'withdrawn',
+      date: '2026-01-15',
+      call: 'acdc/174',
+      timestamp: 120,
+    });
+  });
+});

--- a/src/domain/eips/headlinerHistory.ts
+++ b/src/domain/eips/headlinerHistory.ts
@@ -1,0 +1,40 @@
+import type { ForkRelationship, ProtocolCallReference } from '../../types/eip';
+
+export type HeadlinerHistoryEntry = NonNullable<ForkRelationship['headlinerHistory']>[number];
+export type HeadlinerCandidacyStateEntry = Extract<HeadlinerHistoryEntry, { type: 'proposed' | 'withdrawn' }>;
+export type HeadlinerProposalEntry = Extract<HeadlinerHistoryEntry, { type: 'proposed' }>;
+export type HeadlinerCallEntry = Extract<HeadlinerHistoryEntry, { call?: ProtocolCallReference }> & {
+  call: ProtocolCallReference;
+};
+
+export const getHeadlinerHistory = (fork?: Pick<ForkRelationship, 'headlinerHistory'>): HeadlinerHistoryEntry[] =>
+  fork?.headlinerHistory ?? [];
+
+export const hasHeadlinerHistory = (fork?: Pick<ForkRelationship, 'headlinerHistory'>): boolean =>
+  getHeadlinerHistory(fork).length > 0;
+
+export const isHeadlinerCandidacyState = (entry: HeadlinerHistoryEntry): entry is HeadlinerCandidacyStateEntry =>
+  entry.type === 'proposed' || entry.type === 'withdrawn';
+
+export const getCurrentHeadlinerCandidacyState = (
+  fork?: Pick<ForkRelationship, 'headlinerHistory'>,
+): HeadlinerCandidacyStateEntry | undefined =>
+  [...getHeadlinerHistory(fork)].reverse().find(isHeadlinerCandidacyState);
+
+export const hasActiveHeadlinerCandidacy = (fork?: Pick<ForkRelationship, 'headlinerHistory'>): boolean =>
+  getCurrentHeadlinerCandidacyState(fork)?.type === 'proposed';
+
+export const getHeadlinerProposal = (
+  fork?: Pick<ForkRelationship, 'headlinerHistory'>,
+): HeadlinerProposalEntry | undefined =>
+  getHeadlinerHistory(fork).find((entry): entry is HeadlinerProposalEntry =>
+    entry.type === 'proposed'
+  );
+
+export const hasHeadlinerCall = (entry: HeadlinerHistoryEntry): entry is HeadlinerCallEntry =>
+  'call' in entry && Boolean(entry.call);
+
+export const getLatestHeadlinerCall = (
+  fork?: Pick<ForkRelationship, 'headlinerHistory'>,
+): HeadlinerCallEntry | undefined =>
+  [...getHeadlinerHistory(fork)].reverse().find(hasHeadlinerCall);

--- a/src/domain/eips/headlinerSelection.test.ts
+++ b/src/domain/eips/headlinerSelection.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { HeadlinerSelection } from '../../types/eip';
+import {
+  getSelectedHeadlinerIds,
+  isHeadlinerSelectionFinalized,
+  isSelectedHeadlinerId,
+} from './headlinerSelection';
+
+describe('headlinerSelection', () => {
+  it('derives selected ids from the fork-level layer slots', () => {
+    const selection: HeadlinerSelection = {
+      status: 'finalized',
+      selected: {
+        EL: 7928,
+        CL: 7732,
+      },
+    };
+
+    expect(getSelectedHeadlinerIds(selection)).toEqual([7928, 7732]);
+    expect(isSelectedHeadlinerId(selection, 7928)).toBe(true);
+    expect(isSelectedHeadlinerId(selection, 7805)).toBe(false);
+    expect(isHeadlinerSelectionFinalized(selection)).toBe(true);
+  });
+});

--- a/src/domain/eips/headlinerSelection.ts
+++ b/src/domain/eips/headlinerSelection.ts
@@ -1,0 +1,14 @@
+import type { HeadlinerSelection, HeadlinerSelectionLayer } from '../../types/eip';
+
+export const HEADLINER_SELECTION_LAYERS: HeadlinerSelectionLayer[] = ['EL', 'CL'];
+
+export const getSelectedHeadlinerIds = (selection?: HeadlinerSelection): number[] =>
+  HEADLINER_SELECTION_LAYERS
+    .map((layer) => selection?.selected[layer])
+    .filter((eipId): eipId is number => eipId !== undefined);
+
+export const isSelectedHeadlinerId = (selection: HeadlinerSelection | undefined, eipId: number): boolean =>
+  getSelectedHeadlinerIds(selection).includes(eipId);
+
+export const isHeadlinerSelectionFinalized = (selection?: HeadlinerSelection): boolean =>
+  selection?.status === 'finalized';

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -5,31 +5,53 @@ export interface ClientTeamPerspective {
   candidateBlogPostUrl?: string; // For non-headliner (CFI/PFI) commentary
 }
 
+export type ProtocolCallReference = `${'acdc' | 'acde' | 'acdt'}/${number}`;
+
+export type ForkStatus = 'Proposed' | 'Considered' | 'Scheduled' | 'Declined' | 'Included' | 'Withdrawn';
+
+export interface ForkStatusHistoryEntry {
+  status: ForkStatus;
+  call: ProtocolCallReference | null;
+  date: string | null;
+  timestamp?: number; // Seconds into the call recording video
+}
+
+export interface DiscussionHistoryEntry {
+  call: ProtocolCallReference;
+  date: string;
+  timestamp?: number; // Seconds into the call recording video
+}
+
+export type HeadlinerHistoryEntry =
+  | { type: 'proposed'; date: string; link: string }
+  | { type: 'presented'; date: string; call: ProtocolCallReference; timestamp?: number }
+  | { type: 'withdrawn'; date?: string; call?: ProtocolCallReference; timestamp?: number };
+
+export type HeadlinerSelectionLayer = 'EL' | 'CL';
+
+export interface HeadlinerSelection {
+  status: 'open' | 'finalized';
+  selected: Partial<Record<HeadlinerSelectionLayer, number>>;
+  decided?: {
+    date?: string;
+    call?: ProtocolCallReference;
+    timestamp?: number;
+  };
+}
+
 export interface ForkRelationship {
   forkName: string;
-  statusHistory: Array<{
-    status: 'Proposed' | 'Considered' | 'Scheduled' | 'Declined' | 'Included' | 'Withdrawn';
-    call: `${'acdc' | 'acde' | 'acdt'}/${number}` | null;
-    date: string | null;
-    timestamp?: number; // Seconds into the call recording video
-  }>; // Ordered oldest -> newest
-  isHeadliner?: boolean;
-  wasHeadlinerCandidate?: boolean;
+  statusHistory: ForkStatusHistoryEntry[]; // Ordered oldest -> newest
+  headlinerHistory?: HeadlinerHistoryEntry[]; // Ordered oldest -> newest
   /** Maximum 2 champions allowed */
   champions?: Champion[];
   notice?: {
     title: string;
     text: string;
-    call?: `${'acdc' | 'acde' | 'acdt'}/${number}`;
+    call?: ProtocolCallReference;
     timestamp?: number;
   };
-  presentationHistory?: Array<{
-    type: 'headliner_proposal' | 'headliner_presentation' | 'presentation' | 'debate';
-    call?: `${'acdc' | 'acde' | 'acdt'}/${number}`;
-    link?: string;
-    date: string;
-    timestamp?: number; // Seconds into the call recording video
-  }>;
+  discussionHistory?: DiscussionHistoryEntry[];
 }
 
 export interface Champion {
@@ -114,7 +136,7 @@ export interface KeyDecision {
   type: KeyDecisionType;
   eips: number[];
   stage_change?: {
-    to: 'Proposed' | 'Considered' | 'Scheduled' | 'Included' | 'Declined' | 'Withdrawn';
+    to: ForkStatus;
   };
   devnet?: string;
   fork?: string;

--- a/src/utils/eip.test.ts
+++ b/src/utils/eip.test.ts
@@ -108,11 +108,17 @@ describe('getUpgradeAnchorExpansionState', () => {
 
   it('expands headliner proposals for unselected headliner candidate anchors', () => {
     const eip = makeEip({
+      id: 7805,
       forkRelationships: [
         {
           forkName: 'Glamsterdam',
-          wasHeadlinerCandidate: true,
-          isHeadliner: false,
+          headlinerHistory: [
+            {
+              type: 'proposed',
+              date: '2025-05-26',
+              link: 'https://example.com/headliner-proposal',
+            },
+          ],
           statusHistory: [
             { status: 'Considered', call: null, date: null },
             { status: 'Declined', call: 'acdc/171', date: '2025-12-11' },
@@ -129,11 +135,17 @@ describe('getUpgradeAnchorExpansionState', () => {
 
   it('does not expand headliner proposals for selected headliner anchors', () => {
     const eip = makeEip({
+      id: 7928,
       forkRelationships: [
         {
           forkName: 'Glamsterdam',
-          wasHeadlinerCandidate: true,
-          isHeadliner: true,
+          headlinerHistory: [
+            {
+              type: 'proposed',
+              date: '2025-05-26',
+              link: 'https://example.com/headliner-proposal',
+            },
+          ],
           statusHistory: [
             { status: 'Scheduled', call: null, date: null },
           ],

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -1,4 +1,11 @@
 import { EIP, ForkRelationship, InclusionStage, ProposalType } from '../types/eip';
+import { getUpgradeById } from '../data/upgrades';
+import {
+  getHeadlinerProposal,
+  hasActiveHeadlinerCandidacy,
+  hasHeadlinerHistory,
+} from '../domain/eips/headlinerHistory';
+import { isSelectedHeadlinerId } from '../domain/eips/headlinerSelection';
 
 type ForkStatus = ForkRelationship['statusHistory'][number]['status'];
 
@@ -39,6 +46,9 @@ function isInclusionStage(stage: string): stage is InclusionStage {
   return inclusionStageRanks.has(stage as InclusionStage);
 }
 
+const getForkHeadlinerSelection = (forkName?: string) =>
+  forkName ? getUpgradeById(forkName.toLowerCase())?.headlinerSelection : undefined;
+
 /**
  * Get the inclusion stage for an EIP in a specific fork
  */
@@ -67,7 +77,6 @@ export const getInclusionStageSortRank = (stage: string): number =>
 
 /**
  * Get the headliner discussion link for an EIP in a specific fork
- * Looks for a headliner_proposal entry in presentationHistory
  */
 export const getHeadlinerDiscussionLink = (eip: EIP, forkName?: string): string | null => {
   if (!forkName) return null;
@@ -76,13 +85,7 @@ export const getHeadlinerDiscussionLink = (eip: EIP, forkName?: string): string 
     fork.forkName.toLowerCase() === forkName.toLowerCase()
   );
 
-  if (!forkRelationship?.presentationHistory) return null;
-
-  const headlinerProposal = forkRelationship.presentationHistory.find(
-    p => p.type === 'headliner_proposal'
-  );
-
-  return headlinerProposal?.link || null;
+  return getHeadlinerProposal(forkRelationship)?.link || null;
 };
 
 /**
@@ -94,7 +97,7 @@ export const isHeadliner = (eip: EIP, forkName?: string): boolean => {
   const forkRelationship = eip.forkRelationships.find(fork =>
     fork.forkName.toLowerCase() === forkName.toLowerCase()
   );
-  return forkRelationship?.isHeadliner || false;
+  return Boolean(forkRelationship) && isSelectedHeadlinerId(getForkHeadlinerSelection(forkName), eip.id);
 };
 
 /**
@@ -154,7 +157,7 @@ export const wasHeadlinerCandidate = (eip: EIP, forkName?: string): boolean => {
   const forkRelationship = eip.forkRelationships.find(fork =>
     fork.forkName.toLowerCase() === forkName.toLowerCase()
   );
-  if (!forkRelationship?.wasHeadlinerCandidate) return false;
+  if (!forkRelationship || !hasActiveHeadlinerCandidacy(forkRelationship)) return false;
 
   // Exclude withdrawn proposals
   const latestStatus = forkRelationship.statusHistory[forkRelationship.statusHistory.length - 1]?.status;
@@ -218,7 +221,9 @@ export const sortByLayer = <T extends { layer?: 'EL' | 'CL' | string | null }>(a
  * Check if an EIP is a selected headliner in ANY fork
  */
 export const isHeadlinerInAnyFork = (eip: EIP): boolean => {
-  return eip.forkRelationships.some(fork => fork.isHeadliner === true);
+  return eip.forkRelationships.some(fork =>
+    isSelectedHeadlinerId(getForkHeadlinerSelection(fork.forkName), eip.id)
+  );
 };
 
 /**
@@ -228,7 +233,8 @@ export const wasHeadlinerCandidateInAnyFork = (eip: EIP): boolean => {
   // If selected in any fork, this returns false
   if (isHeadlinerInAnyFork(eip)) return false;
   return eip.forkRelationships.some(fork => {
-    if (!fork.wasHeadlinerCandidate) return false;
+    if (!hasHeadlinerHistory(fork)) return false;
+    if (!hasActiveHeadlinerCandidacy(fork)) return false;
     const latestStatus = fork.statusHistory[fork.statusHistory.length - 1]?.status;
     return latestStatus !== 'Withdrawn';
   });


### PR DESCRIPTION
## What changed

Refines the fork relationship timeline model so each field has a narrower domain meaning:

- keeps `statusHistory` as the inclusion state machine for fork status transitions
- replaces mixed `presentationHistory` entries with generic `discussionHistory` call references
- moves headliner-specific proposal and presentation metadata into `headlinerCandidacy`
- derives the rendered EIP timeline from those domain records and dedupes discussion/headliner presentation rows when the same call/date is already represented by a status transition
- migrates the existing EIP JSON records and schema to the new shape

## Why

Issue #242 called out that a standalone `Presented` timeline entry is not useful when it duplicates a proposal/status reference, and that the old `statusHistory` / `presentationHistory` split was mixing responsibilities through event enums.

The new boundary keeps persistence simple: inclusion status transitions remain separate from non-transition discussion references. The UI gets a complete timeline by projection instead of requiring the raw domain model to be one all-purpose event log.

## Validation

- `npm test`
- `npm run check`
- `npm run build`

Fixes #242