### PR TITLE
Add call publications to the RSS feed

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -60,9 +60,10 @@ Available files vary by call:
 Recent ACDE and ACDC calls (from ~Oct 2025 onward) include `tldr.json` and `key_decisions.json`. Older calls only have transcripts and chat logs. Bundled breakouts suffix each artifact by kind (`tldr_cl.json`, `transcript_cl.vtt`).
 
 ### `/feed.xml`
-RSS 2.0, newest first, carrying two kinds of item:
-- EIP inclusion-stage changes, each with the EIP's plain-language description
+RSS 2.0, newest first, carrying three kinds of item:
+- EIP inclusion-stage changes, each with the EIP's own one-line description from its spec
 - Network activations — mainnet, testnet, and devnet — titled like "Fusaka Live on Mainnet"
+- Protocol calls whose page has gone live, titled like "AllCoreDevs - Consensus #184 call published" and linking to it. Title and link only: none of the call's summary or decision text is in the feed.
 
 `pubDate` is the date of the event itself, not of publication, and `guid` is stable across rebuilds.
 

--- a/src/data/feed.ts
+++ b/src/data/feed.ts
@@ -14,9 +14,16 @@ export interface FeedConfig {
    * list are not published.
    */
   networkActivations: { enabled: boolean };
+  /**
+   * One item per published protocol call: its name, date, and page link only.
+   * None of the call's synced summary or decision text enters the feed, so
+   * the post-publish QA round never has anything here to retract.
+   */
+  callsPublished: { enabled: boolean };
 }
 
 export const feedConfig: FeedConfig = {
   eipStageChanges: { enabled: true },
   networkActivations: { enabled: true },
+  callsPublished: { enabled: true },
 };

--- a/src/domain/eips/stageChanges.test.ts
+++ b/src/domain/eips/stageChanges.test.ts
@@ -106,7 +106,7 @@ describe('getStageChanges', () => {
     expect(getStageChanges([eip])).toEqual([]);
   });
 
-  it('strips the prefix from the title, detects RIP, and prefers the layman description', () => {
+  it('strips the prefix from the title, detects RIP, and keeps both descriptions apart', () => {
     const rip = makeEip({
       id: 7212,
       title: 'RIP-7212: Precompile for secp256r1',
@@ -120,6 +120,7 @@ describe('getStageChanges', () => {
     expect(change.title).toBe('Precompile for secp256r1');
     expect(change.prefix).toBe('RIP');
     expect(change.description).toBe('A friendly summary');
+    expect(change.specDescription).toBe('tech');
     expect(change.url).toBe('/eips/7212');
   });
 });

--- a/src/domain/eips/stageChanges.ts
+++ b/src/domain/eips/stageChanges.ts
@@ -9,7 +9,14 @@ export interface EipStageChange {
   title: string;
   prefix: 'EIP' | 'RIP';
   status: string;
+  /** The plain-language rewrite when one has been written, else the spec one-liner. */
   description: string;
+  /**
+   * The EIP's own one-liner from its spec preamble, never the plain-language
+   * rewrite. Empty when the EIP has none. `/feed.xml` uses this: the rewrite is
+   * hand-authored prose that gets revised, and a feed item can't be recalled.
+   */
+  specDescription: string;
   /** YYYY-MM-DD of the most recent dated status entry. */
   lastStageChange: string;
   lastStageChangeFork: string | null;
@@ -80,6 +87,7 @@ export function getStageChanges(eips: EIP[], count?: number): EipStageChange[] {
       prefix: getProposalPrefix(eip),
       status: eip.status,
       description: eip.laymanDescription || eip.description,
+      specDescription: eip.description,
       lastStageChange: lastUpdate.toISOString().split('T')[0],
       lastStageChangeFork: forkName,
       currentStage,

--- a/src/domain/feed/feed.test.ts
+++ b/src/domain/feed/feed.test.ts
@@ -5,10 +5,12 @@ import type { EipStageChange } from '../eips/stageChanges';
 import {
   buildFeedItems,
   buildRssXml,
+  callPublishedToFeedItem,
   escapeXml,
   stageChangeToFeedItem,
   timelineEventToFeedItem,
   toRssDate,
+  type CallPublished,
 } from './feed';
 
 const makeStageChange = (overrides: Partial<EipStageChange> = {}): EipStageChange => ({
@@ -32,9 +34,18 @@ const makeEvent = (overrides: Partial<TimelineEvent> = {}): TimelineEvent => ({
   ...overrides,
 });
 
+const makeCallPublished = (overrides: Partial<CallPublished> = {}): CallPublished => ({
+  path: 'acdc/184',
+  displayName: 'AllCoreDevs - Consensus',
+  number: '184',
+  date: '2026-08-06',
+  ...overrides,
+});
+
 const config = (overrides: Partial<FeedConfig> = {}): FeedConfig => ({
   eipStageChanges: { enabled: true },
   networkActivations: { enabled: true },
+  callsPublished: { enabled: true },
   ...overrides,
 });
 
@@ -98,24 +109,48 @@ describe('timelineEventToFeedItem', () => {
   });
 });
 
+describe('callPublishedToFeedItem', () => {
+  it('carries only the call name, date, and page link, never synced text', () => {
+    const item = callPublishedToFeedItem(makeCallPublished(), 'https://forkcast.org');
+    expect(item.title).toBe('AllCoreDevs - Consensus #184 call published');
+    expect(item.link).toBe('https://forkcast.org/calls/acdc/184');
+    expect(item.guid).toBe('call-acdc-184-2026-08-06');
+    expect(item.description).toBeUndefined();
+  });
+
+  it('keeps the number exactly as displayed, leading zeros included', () => {
+    const item = callPublishedToFeedItem(
+      makeCallPublished({ path: 'aa/002', displayName: 'Frame Transaction Breakout', number: '002', date: '2026-08-25' }),
+      'https://forkcast.org',
+    );
+    expect(item.title).toBe('Frame Transaction Breakout #002 call published');
+    expect(item.guid).toBe('call-aa-002-2026-08-25');
+  });
+});
+
 describe('buildFeedItems', () => {
   const sources = {
     stageChanges: [makeStageChange()],
     events: [makeEvent()],
+    callsPublished: [makeCallPublished()],
   };
 
   it('emits nothing for a type whose switch is off', () => {
     const items = buildFeedItems(
-      config({ eipStageChanges: { enabled: false }, networkActivations: { enabled: false } }),
+      config({
+        eipStageChanges: { enabled: false },
+        networkActivations: { enabled: false },
+        callsPublished: { enabled: false },
+      }),
       sources,
       'https://forkcast.org',
     );
     expect(items).toEqual([]);
   });
 
-  it('emits only stage changes when network activations are off', () => {
+  it('emits only stage changes when the other switches are off', () => {
     const items = buildFeedItems(
-      config({ networkActivations: { enabled: false } }),
+      config({ networkActivations: { enabled: false }, callsPublished: { enabled: false } }),
       sources,
       'https://forkcast.org',
     );
@@ -134,22 +169,25 @@ describe('buildFeedItems', () => {
           makeEvent({ title: 'Ethereum Turns 10! 🎉', date: '2025-07-30', category: 'milestone' }),
           makeEvent({ title: 'Something was announced', date: '2025-07-31', category: 'announcement' }),
         ],
+        callsPublished: [],
       },
       'https://forkcast.org',
     );
     expect(items.map((item) => item.title)).toEqual(['Fusaka Live on Mainnet']);
   });
 
-  it('interleaves both types newest first', () => {
+  it('interleaves all types newest first', () => {
     const items = buildFeedItems(
       config(),
       {
         stageChanges: [makeStageChange(), makeStageChange({ id: 7702, lastStageChange: '2025-11-01' })],
         events: [makeEvent(), makeEvent({ title: 'Fusaka Live on Hoodi Testnet', date: '2026-03-01' })],
+        callsPublished: [makeCallPublished()],
       },
       'https://forkcast.org',
     );
     expect(items.map((item) => item.date)).toEqual([
+      '2026-08-06',
       '2026-03-01',
       '2026-01-08',
       '2025-12-03',

--- a/src/domain/feed/feed.test.ts
+++ b/src/domain/feed/feed.test.ts
@@ -18,7 +18,8 @@ const makeStageChange = (overrides: Partial<EipStageChange> = {}): EipStageChang
   title: 'Enshrined Proposer-Builder Separation',
   prefix: 'EIP',
   status: 'Draft',
-  description: 'Separates block proposal from block building.',
+  description: 'A friendly rewrite that must never reach the feed.',
+  specDescription: 'Separates block proposal from block building.',
   lastStageChange: '2026-01-08',
   lastStageChangeFork: 'Glamsterdam',
   currentStage: 'Scheduled for Inclusion',
@@ -36,7 +37,7 @@ const makeEvent = (overrides: Partial<TimelineEvent> = {}): TimelineEvent => ({
 
 const makeCallPublished = (overrides: Partial<CallPublished> = {}): CallPublished => ({
   path: 'acdc/184',
-  displayName: 'AllCoreDevs - Consensus',
+  seriesName: 'AllCoreDevs - Consensus',
   number: '184',
   date: '2026-08-06',
   ...overrides,
@@ -70,6 +71,20 @@ describe('stageChangeToFeedItem', () => {
       'EIP-8261 (Gas Limit Schedule) is now Scheduled (Informational) for Glamsterdam',
     );
     expect(item.guid).toBe('eip-8261-informational-2026-01-08');
+  });
+
+  it("carries the EIP's spec one-liner, never the hand-authored rewrite", () => {
+    // The rewrite is revised after publication; a feed item can't be recalled.
+    const item = stageChangeToFeedItem(makeStageChange(), 'https://forkcast.org');
+    expect(item.description).toBe('Separates block proposal from block building.');
+  });
+
+  it('omits the description for an EIP whose spec carries none', () => {
+    const item = stageChangeToFeedItem(
+      makeStageChange({ specDescription: '' }),
+      'https://forkcast.org',
+    );
+    expect(item.description).toBeUndefined();
   });
 
   it('falls back to the EIP status when no current stage exists', () => {
@@ -120,11 +135,31 @@ describe('callPublishedToFeedItem', () => {
 
   it('keeps the number exactly as displayed, leading zeros included', () => {
     const item = callPublishedToFeedItem(
-      makeCallPublished({ path: 'aa/002', displayName: 'Frame Transaction Breakout', number: '002', date: '2026-08-25' }),
+      makeCallPublished({
+        path: 'aa/002',
+        seriesName: 'Frame Transaction Breakout',
+        number: '002',
+        date: '2026-08-25',
+      }),
       'https://forkcast.org',
     );
     expect(item.title).toBe('Frame Transaction Breakout #002 call published');
     expect(item.guid).toBe('call-aa-002-2026-08-25');
+  });
+
+  it('drops the series number for a one-off, which names and numbers itself', () => {
+    const item = callPublishedToFeedItem(
+      makeCallPublished({
+        path: 'one-off-1971/001',
+        seriesName: 'one-off-1971',
+        name: 'ERC-8004 Launch Day, #1',
+        number: '001',
+        date: '2026-03-17',
+      }),
+      'https://forkcast.org',
+    );
+    expect(item.title).toBe('ERC-8004 Launch Day, #1 call published');
+    expect(item.guid).toBe('call-one-off-1971-001-2026-03-17');
   });
 });
 

--- a/src/domain/feed/feed.ts
+++ b/src/domain/feed/feed.ts
@@ -17,8 +17,10 @@ export interface FeedItem {
 export interface CallPublished {
   /** `path` of an entry in `protocolCalls` ("acdc/184"). */
   path: string;
-  /** The call's display name ("AllCoreDevs - Consensus"). */
-  displayName: string;
+  /** The series' display name ("AllCoreDevs - Consensus"). */
+  seriesName: string;
+  /** A one-off call's hand-written name, which already reads as a full title. */
+  name?: string;
   /** The call's number as displayed ("184", "002"). */
   number: string;
   /** YYYY-MM-DD, the call's date. */
@@ -45,7 +47,7 @@ export function stageChangeToFeedItem(change: EipStageChange, site: string): Fee
     link: `${site}${change.url}`,
     guid: `${change.prefix.toLowerCase()}-${change.id}-${slugify(stage)}-${change.lastStageChange}`,
     date: change.lastStageChange,
-    description: change.description || undefined,
+    description: change.specDescription || undefined,
   };
 }
 
@@ -69,8 +71,11 @@ export function timelineEventToFeedItem(event: TimelineEvent, site: string): Fee
  * QA round after publish) can reach a reader's feed.
  */
 export function callPublishedToFeedItem(call: CallPublished, site: string): FeedItem {
+  // A hand-written name carries its own numbering, so it takes no series
+  // number — the same rule the call's own page title uses.
+  const name = call.name ?? `${call.seriesName} #${call.number}`;
   return {
-    title: `${call.displayName} #${call.number} call published`,
+    title: `${name} call published`,
     link: `${site}/calls/${call.path}`,
     guid: `call-${slugify(call.path)}-${call.date}`,
     date: call.date,

--- a/src/domain/feed/feed.ts
+++ b/src/domain/feed/feed.ts
@@ -13,6 +13,18 @@ export interface FeedItem {
   description?: string;
 }
 
+/** A protocol call whose page is live, reduced to fields no bot wrote. */
+export interface CallPublished {
+  /** `path` of an entry in `protocolCalls` ("acdc/184"). */
+  path: string;
+  /** The call's display name ("AllCoreDevs - Consensus"). */
+  displayName: string;
+  /** The call's number as displayed ("184", "002"). */
+  number: string;
+  /** YYYY-MM-DD, the call's date. */
+  date: string;
+}
+
 const slugify = (value: string): string =>
   value
     .toLowerCase()
@@ -52,6 +64,20 @@ export function timelineEventToFeedItem(event: TimelineEvent, site: string): Fee
 }
 
 /**
+ * Title-only by design: the item says a call's page exists and links it,
+ * nothing more, so none of the synced summary or decision text (which gets a
+ * QA round after publish) can reach a reader's feed.
+ */
+export function callPublishedToFeedItem(call: CallPublished, site: string): FeedItem {
+  return {
+    title: `${call.displayName} #${call.number} call published`,
+    link: `${site}/calls/${call.path}`,
+    guid: `call-${slugify(call.path)}-${call.date}`,
+    date: call.date,
+  };
+}
+
+/**
  * `timelineEvents` also carries community milestones and announcements, which
  * are neither about a network nor something a reader can follow a link to.
  */
@@ -70,6 +96,7 @@ export function buildFeedItems(
   sources: {
     stageChanges: EipStageChange[];
     events: TimelineEvent[];
+    callsPublished: CallPublished[];
   },
   site: string,
 ): FeedItem[] {
@@ -85,6 +112,10 @@ export function buildFeedItems(
         .filter((event) => ACTIVATION_CATEGORIES.has(event.category))
         .map((event) => timelineEventToFeedItem(event, site)),
     );
+  }
+
+  if (config.callsPublished.enabled) {
+    items.push(...sources.callsPublished.map((call) => callPublishedToFeedItem(call, site)));
   }
 
   return items.sort((a, b) => b.date.localeCompare(a.date) || a.guid.localeCompare(b.guid));

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,9 +1,12 @@
 import type { APIRoute } from 'astro';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { getCallDisplayName, protocolCalls } from '../data/calls';
 import { eipsData } from '../data/eips';
 import { timelineEvents } from '../data/events';
 import { feedConfig } from '../data/feed';
 import { getStageChanges } from '../domain/eips/stageChanges';
-import { buildFeedItems, buildRssXml } from '../domain/feed/feed';
+import { buildFeedItems, buildRssXml, type CallPublished } from '../domain/feed/feed';
 
 // Emitted as a static artifact during `astro build`, served at
 // https://forkcast.org/feed.xml. What it may contain is controlled by the
@@ -12,10 +15,27 @@ export const prerender = true;
 
 const SITE = (import.meta.env.SITE ?? 'https://forkcast.org').replace(/\/$/, '');
 
+/**
+ * A call is published once its synced artifact directory exists, which is
+ * also what makes its page substantive. Scheduled future calls have no
+ * directory yet and arrive in the feed on the rebuild after their sync.
+ */
+const publishedCalls = (): CallPublished[] =>
+  protocolCalls
+    .filter((call) =>
+      existsSync(join(process.cwd(), 'public', 'artifacts', call.type, `${call.date}_${call.number}`)),
+    )
+    .map((call) => ({
+      path: call.path,
+      displayName: getCallDisplayName(call),
+      number: call.number,
+      date: call.date,
+    }));
+
 export const GET: APIRoute = () => {
   const items = buildFeedItems(
     feedConfig,
-    { stageChanges: getStageChanges(eipsData), events: timelineEvents },
+    { stageChanges: getStageChanges(eipsData), events: timelineEvents, callsPublished: publishedCalls() },
     SITE,
   );
 

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,7 +1,5 @@
 import type { APIRoute } from 'astro';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { getCallDisplayName, protocolCalls } from '../data/calls';
+import { getCallTypeName, protocolCalls } from '../data/calls';
 import { eipsData } from '../data/eips';
 import { timelineEvents } from '../data/events';
 import { feedConfig } from '../data/feed';
@@ -16,21 +14,18 @@ export const prerender = true;
 const SITE = (import.meta.env.SITE ?? 'https://forkcast.org').replace(/\/$/, '');
 
 /**
- * A call is published once its synced artifact directory exists, which is
- * also what makes its page substantive. Scheduled future calls have no
- * directory yet and arrive in the feed on the rebuild after their sync.
+ * scripts/sync-call-assets.mjs appends to `protocolCalls` only once a call has
+ * a video and a transcript or tldr, so every entry is a published call. An
+ * upcoming call joins the feed on the rebuild after its sync.
  */
 const publishedCalls = (): CallPublished[] =>
-  protocolCalls
-    .filter((call) =>
-      existsSync(join(process.cwd(), 'public', 'artifacts', call.type, `${call.date}_${call.number}`)),
-    )
-    .map((call) => ({
-      path: call.path,
-      displayName: getCallDisplayName(call),
-      number: call.number,
-      date: call.date,
-    }));
+  protocolCalls.map((call) => ({
+    path: call.path,
+    seriesName: getCallTypeName(call.type),
+    name: call.name,
+    number: call.number,
+    date: call.date,
+  }));
 
 export const GET: APIRoute = () => {
   const items = buildFeedItems(

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -349,7 +349,7 @@ describe('build output', () => {
       expect([...xml.matchAll(/<item>/g)].length).toBeGreaterThan(0);
     });
 
-    it('carries both enabled item types', () => {
+    it('carries every enabled item type', () => {
       // Each source is wired separately, so one can go silent while the feed
       // still validates and looks healthy.
       const guids = [...read().matchAll(/<guid isPermaLink="false">([^<]+)<\/guid>/g)].map(
@@ -357,6 +357,7 @@ describe('build output', () => {
       );
       expect(guids.some((g) => g.startsWith('eip-'))).toBe(true);
       expect(guids.some((g) => g.startsWith('event-'))).toBe(true);
+      expect(guids.some((g) => g.startsWith('call-'))).toBe(true);
     });
 
     it('every item has a unique guid', () => {


### PR DESCRIPTION
﻿The follow-on you suggested after merging #366, @wolovim: one item per published call, carrying only the call's name, number, date, and page link. None of the synced summary or decision text enters the feed, so the post-publish QA round never has anything here to retract.

A call counts as published once its artifact directory exists, which is the same moment its page becomes substantive. Scheduled future calls have no directory yet and arrive in the feed on the rebuild after their sync. The switch is on in this draft since every field is human-committed data, easy to flip if you'd rather stage it.

Titles read "AllCoreDevs - Execution #244 call published" and GUIDs are call-{path}-{date}, deterministic like the others. The feed unit tests cover the new type and the build-output feed test now asserts all three guid families appear.
