### PR TITLE
fix: Adjust ADCE 244 video start time

### DIFF
--- a/public/artifacts/acde/2026-08-27_244/config.json
+++ b/public/artifacts/acde/2026-08-27_244/config.json
@@ -3,6 +3,6 @@
   "videoUrl": "https://youtube.com/watch?v=Olt0GbiEvks",
   "sync": {
     "transcriptStartTime": "00:09:56",
-    "videoStartTime": "00:09:32"
+    "videoStartTime": "00:09:30"
   }
 }


### PR DESCRIPTION
The transcript and video sync is a bit off. Fixing it in context of #368, so skips are correctly timed.