### PR TITLE
calls: Add skip gap feature

### DIFF
--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -12,6 +12,11 @@ import { onOpenCallSearch } from '../../domain/calls/callSearch';
 import { eipsData } from '../../data/eips';
 import { EIP, ForkRelationship, KeyDecision } from '../../types/eip';
 import { isSearchHotkey } from '../search/searchShortcuts';
+import {
+  GAP_SKIP_WAIT_SECONDS,
+  computeGapSkipIntervals,
+  findGapSkipTarget,
+} from '../../utils/gapSkip';
 
 // Mapping of breakout call types to their associated EIP IDs
 const BREAKOUT_EIP_MAP: Record<string, number> = {
@@ -341,6 +346,78 @@ const loadMainCallData = async (
   };
 };
 
+// Parses a VTT transcript into per-message entries. Cue lines carry
+// `start --> end` timecodes; endTimestamp powers the gap detection that
+// fast-forwards the video to the next message after long silences.
+const parseVTTTranscript = (text: string) => {
+  const lines = text.split('\n');
+  const entries: Array<{
+    timestamp: string;
+    endTimestamp?: string;
+    speaker: string;
+    text: string;
+  }> = [];
+  let currentEntry: Partial<{
+    timestamp: string;
+    endTimestamp: string;
+    speaker: string;
+    text: string;
+  }> = {};
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    // Skip WEBVTT header and empty lines
+    if (line === 'WEBVTT' || line === '' || /^\d+$/.test(line)) {
+      continue;
+    }
+
+    // Parse the "start --> end" timecode line
+    if (line.includes('-->')) {
+      const timeMatch = line.match(
+        /(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})/,
+      );
+      if (timeMatch) {
+        currentEntry.timestamp = timeMatch[1];
+        currentEntry.endTimestamp = timeMatch[2];
+      }
+      continue;
+    }
+
+    // Parse text content (speaker and text are on the same line)
+    if (line && currentEntry.timestamp) {
+      // Look for speaker pattern like "Speaker: text" or "Speaker | Team: text"
+      const speakerMatch = line.match(/^([^:]+):\s*(.*)$/);
+      if (speakerMatch) {
+        currentEntry.speaker = speakerMatch[1].trim();
+        currentEntry.text = speakerMatch[2].trim();
+      } else {
+        // If no colon pattern, treat the whole line as text
+        currentEntry.speaker = 'Unknown';
+        currentEntry.text = line;
+      }
+
+      if (
+        currentEntry.timestamp &&
+        currentEntry.speaker &&
+        currentEntry.text
+      ) {
+        entries.push(
+          currentEntry as {
+            timestamp: string;
+            endTimestamp?: string;
+            speaker: string;
+            text: string;
+          },
+        );
+        currentEntry = {};
+      }
+    }
+  }
+
+  return entries;
+};
+
 interface CallPageProps {
   /** "series/number", e.g. "acdc/154". Supplied by the Astro route. */
   callPath: string;
@@ -405,6 +482,8 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
   const transcriptScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const isProgrammaticScrollRef = useRef(false);
   const lastHighlightedTimestampRef = useRef<string | null>(null);
+  const [isGapSkipEnabled, setIsGapSkipEnabled] = useState(false);
+  const lastGapSkipTargetRef = useRef<number | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- YouTube player API type is not exported
   const [player, setPlayer] = useState<any>(null);
   const [currentVideoTime, setCurrentVideoTime] = useState(0);
@@ -590,6 +669,7 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
     setCurrentVideoTime(0);
     setIsPlaying(false);
     lastHighlightedTimestampRef.current = null;
+    lastGapSkipTargetRef.current = null;
 
     const loadCallData = async (): Promise<{ result: LoadResult | null; active: ActiveBreakout | null; bundledKinds: string[] }> => {
       // The parent config lists bundled breakouts, needed for tabs on every view.
@@ -678,25 +758,62 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
     };
   }, [player, callConfig, getAdjustedVideoTime]);
 
+  // Video-time gaps between transcript messages that gap-skip fast-forwards.
+  const gapSkipIntervals = useMemo(() => {
+    const sync = callConfig?.sync;
+    if (!sync?.transcriptStartTime || !sync?.videoStartTime) return [];
+    if (!callData?.transcriptContent?.trim()) return [];
+    const entries = parseVTTTranscript(callData.transcriptContent).filter(
+      entry =>
+        timestampToSeconds(entry.timestamp) >=
+        timestampToSeconds(sync.transcriptStartTime),
+    );
+    return computeGapSkipIntervals(entries, sync);
+  }, [callData, callConfig]);
+
+  // Total video time that gap skipping fast-forwards, in seconds.
+  const gapSkipSeconds = useMemo(
+    () =>
+      gapSkipIntervals.reduce(
+        (sum, interval) => sum + interval.target - interval.start - GAP_SKIP_WAIT_SECONDS,
+        0,
+      ),
+    [gapSkipIntervals],
+  );
+
+  const handleGapSkipToggle = () => setIsGapSkipEnabled(!isGapSkipEnabled);
+
   // Poll for video time when playing
   useEffect(() => {
     if (isPlaying && player && callConfig?.sync?.transcriptStartTime && callConfig?.sync?.videoStartTime) {
       pollingIntervalRef.current = setInterval(() => {
         const time = player.getCurrentTime();
         setCurrentVideoTime(time);
+
+        // Fast-forward over silent gaps between transcript messages.
+        if (!isGapSkipEnabled) return;
+        const skipTarget = findGapSkipTarget(time, gapSkipIntervals);
+        if (skipTarget === null) {
+          lastGapSkipTargetRef.current = null;
+          return;
+        }
+        // While a seek is in flight, getCurrentTime lags behind the target;
+        // only re-issue it when the target actually changes.
+        if (lastGapSkipTargetRef.current !== skipTarget) {
+          lastGapSkipTargetRef.current = skipTarget;
+          player.seekTo(skipTarget);
+          player.playVideo();
+          setCurrentVideoTime(skipTarget);
+        }
       }, 100); // Poll every 100ms for smooth highlighting
     } else {
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-      }
+      clearInterval(pollingIntervalRef.current);
     }
 
     return () => {
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-      }
+      clearInterval(pollingIntervalRef.current);
     };
-  }, [isPlaying, player, callConfig]);
+  }, [isPlaying, player, callConfig, gapSkipIntervals, isGapSkipEnabled]);
 
   // Detect manual scrolling on transcript
   useEffect(() => {
@@ -1084,51 +1201,6 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
 
   const breakoutEipInfo = getBreakoutEipInfo();
 
-  const parseVTTTranscript = (text: string) => {
-    const lines = text.split('\n');
-    const entries: Array<{ timestamp: string; speaker: string; text: string }> = [];
-    let currentEntry: Partial<{ timestamp: string; speaker: string; text: string }> = {};
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].trim();
-
-      // Skip WEBVTT header and empty lines
-      if (line === 'WEBVTT' || line === '' || /^\d+$/.test(line)) {
-        continue;
-      }
-
-      // Parse timestamp line
-      if (line.includes('-->')) {
-        const timeMatch = line.match(/(\d{2}:\d{2}:\d{2}\.\d{3})/);
-        if (timeMatch) {
-          currentEntry.timestamp = timeMatch[1];
-        }
-        continue;
-      }
-
-      // Parse text content (speaker and text are on the same line)
-      if (line && currentEntry.timestamp) {
-        // Look for speaker pattern like "Speaker: text" or "Speaker | Team: text"
-        const speakerMatch = line.match(/^([^:]+):\s*(.*)$/);
-        if (speakerMatch) {
-          currentEntry.speaker = speakerMatch[1].trim();
-          currentEntry.text = speakerMatch[2].trim();
-        } else {
-          // If no colon pattern, treat the whole line as text
-          currentEntry.speaker = 'Unknown';
-          currentEntry.text = line;
-        }
-
-        if (currentEntry.timestamp && currentEntry.speaker && currentEntry.text) {
-          entries.push(currentEntry as { timestamp: string; speaker: string; text: string });
-          currentEntry = {};
-        }
-      }
-    }
-
-    return entries;
-  };
-
   const hasTldr = Boolean(callData.tldrData);
   const hasNotes = Boolean(callData.notesData?.sections?.length);
   const hasSummary = hasTldr || hasNotes;
@@ -1435,7 +1507,20 @@ const CallPage: React.FC<CallPageProps> = ({ callPath, upcoming }) => {
       className={`bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${isWorkspaceView ? 'flex min-h-0 flex-col' : ''}`}
       style={isWorkspaceView ? { height: effectiveSidebarHeight } : undefined}
     >
-      <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100 mb-3">Transcript</h2>
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Transcript</h2>
+        {gapSkipIntervals.length > 0 && (
+          <label className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={isGapSkipEnabled}
+              onChange={handleGapSkipToggle}
+              className="w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-purple-600 focus:ring-purple-500"
+            />
+            <span>Skip gaps ({(gapSkipSeconds / 60).toFixed(1)} min)</span>
+          </label>
+        )}
+      </div>
       {callData.transcriptContent?.trim() ? (
         <div
           ref={transcriptRef}

--- a/src/utils/gapSkip.test.ts
+++ b/src/utils/gapSkip.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  GAP_SKIP_LAND_LEAD_SECONDS,
+  GAP_SKIP_WAIT_SECONDS,
+  computeGapSkipIntervals,
+  findGapSkipTarget,
+} from "./gapSkip";
+
+// Gap 1 runs video 10–14 (next message at 14.3); gap 2 runs 20–35.
+const INTERVALS = [
+  { start: 10, target: 14 },
+  { start: 20, target: 35 },
+];
+
+describe("computeGapSkipIntervals", () => {
+  it("includes gaps longer than the threshold, with the target led", () => {
+    const intervals = computeGapSkipIntervals([
+      { timestamp: "00:00:01.000", endTimestamp: "00:00:03.000" },
+      { timestamp: "00:00:07.000", endTimestamp: "00:00:09.000" },
+    ]);
+
+    expect(intervals).toEqual([
+      { start: 3, target: 7 - GAP_SKIP_LAND_LEAD_SECONDS },
+    ]);
+  });
+
+  it("excludes gaps of at most the threshold", () => {
+    // 2s gap (exactly the threshold), then a 1.5s gap.
+    const intervals = computeGapSkipIntervals([
+      { timestamp: "00:00:01.000", endTimestamp: "00:00:03.000" },
+      { timestamp: "00:00:05.000", endTimestamp: "00:00:06.500" },
+    ]);
+
+    expect(intervals).toEqual([]);
+  });
+
+  it("skips messages without a known end time", () => {
+    const intervals = computeGapSkipIntervals([
+      { timestamp: "00:00:01.000" },
+      { timestamp: "00:01:00.000", endTimestamp: "00:01:01.000" },
+    ]);
+
+    expect(intervals).toEqual([]);
+  });
+
+  it("applies the transcript/video sync offset", () => {
+    const intervals = computeGapSkipIntervals(
+      [
+        { timestamp: "00:01:00.000", endTimestamp: "00:01:05.000" },
+        { timestamp: "00:01:10.000", endTimestamp: "00:01:11.000" },
+      ],
+      {
+        transcriptStartTime: "00:01:00.000",
+        videoStartTime: "00:00:30.000",
+      },
+    );
+
+    // transcript 00:01:05 -> video 00:00:35; 00:01:10 -> video 00:00:40, led.
+    expect(intervals).toEqual([
+      { start: 35, target: 40 - GAP_SKIP_LAND_LEAD_SECONDS },
+    ]);
+  });
+});
+
+describe("findGapSkipTarget", () => {
+  it("waits GAP_SKIP_WAIT_SECONDS into the gap before offering a skip", () => {
+    expect(findGapSkipTarget(10, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(10 + GAP_SKIP_WAIT_SECONDS - 0.01, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(10 + GAP_SKIP_WAIT_SECONDS, INTERVALS)).toBe(14);
+  });
+
+  it("returns the next message start from anywhere inside a gap", () => {
+    expect(findGapSkipTarget(12.5, INTERVALS)).toBe(14);
+    expect(findGapSkipTarget(30, INTERVALS)).toBe(35);
+  });
+
+  it("plays out the final GAP_SKIP_MIN_REMAINING_SECONDS of a gap naturally", () => {
+    expect(findGapSkipTarget(13.5, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(34.5, INTERVALS)).toBeNull();
+  });
+
+  it("returns null outside any gap, after the target, and with no intervals", () => {
+    expect(findGapSkipTarget(9, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(17, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(100, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(14, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(35, INTERVALS)).toBeNull();
+    expect(findGapSkipTarget(12.5, [])).toBeNull();
+  });
+});

--- a/src/utils/gapSkip.ts
+++ b/src/utils/gapSkip.ts
@@ -7,7 +7,7 @@ import {
 // Tuning for skipping the silent gaps between transcript messages, in video
 // seconds.
 export const GAP_SKIP_THRESHOLD_SECONDS = 2; // gap must be longer than this to skip
-export const GAP_SKIP_WAIT_SECONDS = 0.5; // let the video play this far into a gap before skipping
+export const GAP_SKIP_WAIT_SECONDS = 0.8; // let the video play this far into a gap before skipping
 export const GAP_SKIP_MIN_REMAINING_SECONDS = 1; // play out naturally once the next message is this close
 export const GAP_SKIP_LAND_LEAD_SECONDS = 0.3; // seek this far before the next message (YouTube lands late, not early)
 

--- a/src/utils/gapSkip.ts
+++ b/src/utils/gapSkip.ts
@@ -1,0 +1,69 @@
+import {
+  getAdjustedVideoTime,
+  timestampToSeconds,
+  type SyncConfig,
+} from './timestamp';
+
+// Tuning for skipping the silent gaps between transcript messages, in video
+// seconds.
+export const GAP_SKIP_THRESHOLD_SECONDS = 2; // gap must be longer than this to skip
+export const GAP_SKIP_WAIT_SECONDS = 0.5; // let the video play this far into a gap before skipping
+export const GAP_SKIP_MIN_REMAINING_SECONDS = 1; // play out naturally once the next message is this close
+export const GAP_SKIP_LAND_LEAD_SECONDS = 0.3; // seek this far before the next message (YouTube lands late, not early)
+
+export interface GapSkipInterval {
+  /** Gap start in video seconds: the previous message's end. */
+  start: number;
+  /** Seek target in video seconds: the next message's start, led. */
+  target: number;
+}
+
+/**
+ * Video-time intervals over the gaps longer than GAP_SKIP_THRESHOLD_SECONDS
+ * between consecutive transcript messages. Entries without a known end time
+ * are skipped; the result is sorted by `start`.
+ */
+export function computeGapSkipIntervals(
+  entries: Array<{ timestamp: string; endTimestamp?: string }>,
+  sync?: SyncConfig,
+): GapSkipInterval[] {
+  const intervals: GapSkipInterval[] = [];
+  for (let i = 0; i < entries.length - 1; i++) {
+    const endTimestamp = entries[i].endTimestamp;
+    if (!endTimestamp) continue;
+    const gapSeconds =
+      timestampToSeconds(entries[i + 1].timestamp) -
+      timestampToSeconds(endTimestamp);
+    if (gapSeconds <= GAP_SKIP_THRESHOLD_SECONDS) continue;
+    intervals.push({
+      start: getAdjustedVideoTime(endTimestamp, sync),
+      target: Math.max(
+        0,
+        getAdjustedVideoTime(entries[i + 1].timestamp, sync) -
+          GAP_SKIP_LAND_LEAD_SECONDS,
+      ),
+    });
+  }
+  return intervals;
+}
+
+/**
+ * The seek target (the next message's start, led) while the video is playing
+ * through a long gap, otherwise null. Respects GAP_SKIP_WAIT_SECONDS (no
+ * skipping in the first moments of a gap) and GAP_SKIP_MIN_REMAINING_SECONDS.
+ * `intervals` must be sorted by `start`.
+ */
+export function findGapSkipTarget(
+  videoTime: number,
+  intervals: GapSkipInterval[],
+): number | null {
+  for (const interval of intervals) {
+    if (videoTime < interval.start + GAP_SKIP_WAIT_SECONDS) break;
+    if (videoTime >= interval.target) continue;
+    if (interval.target - videoTime >= GAP_SKIP_MIN_REMAINING_SECONDS) {
+      return interval.target;
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
Use the timestamps in the transcripts to detect long periods of silence, and skip them.

The feature is optional, the user needs to enable it with a checkbox at the top of the transcript.

# Testing
~Please apply/merge #369 before testing, to make sure the transcript and video are closely in sync, to prevent jumps mid-sentence.~ Done

In ACDE 244 a good place to test the feature is going to [01:33:46](https://deploy-preview-370--eth-forkcast.netlify.app/calls/acde/244/#t=5626) and listening for a couple of minutes.

# Potential issues:
- With this feature enabled the syncing of video and transcripts needs to be tight. Not sure how the current sync is done, if it can be adjusted or if the offset in ACDE 244 is not the norm. **UPDATE**: I checked other recent calls and those were correctly synced. 
- The Youtube UI is displayed when seeking the video, that could be annoying. But since usually the video feed is not displaying anything other than the speaker name it is probably OK. In any case the user can disable the feature.

# Future work:
- Should the skip silence toggle state be saved in local/session storage?

closes #368 