### PR TITLE
Add per-EIP API endpoint /api/eips/{id}.json

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,7 +21,7 @@ The full EIP dataset — every EIP Forkcast tracks, unfiltered. Each record carr
 - `requires[]` — EIP dependencies. `category`, `layer` (`EL` | `CL`) — optional, present when available.
 
 ### `/api/eips/{id}.json`
-One EIP's full record — the same object as in `/api/eips.json`, but a single record (0.5–11 KB) instead of the whole dataset (~580 KB). Use this for single-EIP questions; use the bulk index only when you need many EIPs in one pass. Unknown ids 404.
+One EIP's full record — the same object as in `/api/eips.json`, but a single record (0.2–12 KB) instead of the whole dataset (~580 KB). Use this for single-EIP questions; use the bulk index only when you need many EIPs in one pass. Unknown ids 404.
 
 ### `/api/calls.json`
 Every protocol call, with `type`, `date`, `number`, and `path`. Append `path` to `/artifacts/` to reach that call's files. Includes a `series` map decoding the type slugs (`acde` → "AllCoreDevs - Execution").

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,6 +20,9 @@ The full EIP dataset — every EIP Forkcast tracks, unfiltered. Each record carr
 - `reviewer` (`bot` | `expert` | `staff`) — provenance of that prose. `bot` means no human has vetted it yet.
 - `requires[]` — EIP dependencies. `category`, `layer` (`EL` | `CL`) — optional, present when available.
 
+### `/api/eips/{id}.json`
+One EIP's full record — the same object as in `/api/eips.json`, but a single record (0.5–11 KB) instead of the whole dataset (~580 KB). Use this for single-EIP questions; use the bulk index only when you need many EIPs in one pass. Unknown ids 404.
+
 ### `/api/calls.json`
 Every protocol call, with `type`, `date`, `number`, and `path`. Append `path` to `/artifacts/` to reach that call's files. Includes a `series` map decoding the type slugs (`acde` → "AllCoreDevs - Execution").
 
@@ -90,18 +93,18 @@ A few datasets have no served equivalent. Access via the GitHub API, e.g.
 
 ## Quick reference
 
-| Want                       | How                                                       |
-| -------------------------- | --------------------------------------------------------- |
-| Is EIP X in upgrade Y?     | `GET /api/eips.json` → `forkRelationships[].statusHistory` |
-| What does EIP X do?        | `GET /api/eips.json` → `laymanDescription`, `benefits`     |
-| Raw EIP spec               | `GET /eips/{number}.md`                                    |
-| What changed recently?     | `GET /api/eip-stage-changes.json`                          |
-| Subscribe to changes       | `GET /feed.xml` (RSS; agents should use the JSON above)     |
-| All calls / artifact paths | `GET /api/calls.json`                                      |
-| What was decided about X?  | `GET /search-light.json`                                   |
-| One call's summary         | `GET /artifacts/{series}/{date}_{number}/tldr.json`        |
-| One call's transcript      | `GET /artifacts/{series}/{date}_{number}/transcript.vtt`   |
-| When might upgrade X ship? | `GET /api/upgrades.json` → `projectedActivation` (estimate) |
-| Upcoming agenda context    | `GET /artifacts/{series}/plan/open_action_items.json`      |
-| Event timeline             | GitHub: `src/data/events.ts`                               |
-| Pending proposals          | GitHub: `src/data/pending-proposals.ts`                    |
+| Want                       | How                                                             |
+| -------------------------- | --------------------------------------------------------------- |
+| Is EIP X in upgrade Y?     | `GET /api/eips/{id}.json` → `forkRelationships[].statusHistory` |
+| What does EIP X do?        | `GET /api/eips/{id}.json` → `laymanDescription`, `benefits`     |
+| Raw EIP spec               | `GET /eips/{number}.md`                                         |
+| What changed recently?     | `GET /api/eip-stage-changes.json`                               |
+| Subscribe to changes       | `GET /feed.xml` (RSS; agents should use the JSON above)         |
+| All calls / artifact paths | `GET /api/calls.json`                                           |
+| What was decided about X?  | `GET /search-light.json`                                        |
+| One call's summary         | `GET /artifacts/{series}/{date}_{number}/tldr.json`             |
+| One call's transcript      | `GET /artifacts/{series}/{date}_{number}/transcript.vtt`        |
+| When might upgrade X ship? | `GET /api/upgrades.json` → `projectedActivation` (estimate)     |
+| Upcoming agenda context    | `GET /artifacts/{series}/plan/open_action_items.json`           |
+| Event timeline             | GitHub: `src/data/events.ts`                                    |
+| Pending proposals          | GitHub: `src/data/pending-proposals.ts`                         |

--- a/src/domain/cadence/timeline.ts
+++ b/src/domain/cadence/timeline.ts
@@ -46,7 +46,7 @@ export const FORK_SPEC_LINES: Record<string, number> = {
  * anything above; `timeline.test.ts` recomputes it too.
  */
 export const NEXT_FORK_SPEC_LINES: Record<string, number> = {
-  Glamsterdam: 4135,
+  Glamsterdam: 4172,
 };
 
 /**

--- a/src/pages/api/eips/[id].json.ts
+++ b/src/pages/api/eips/[id].json.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from 'astro';
+import { eipById, eipsData } from '../../../data/eips';
+
+// Emitted as one static artifact per EIP during `astro build`, served at
+// https://forkcast.org/api/eips/{id}.json.
+//
+// Dev-server quirk (Astro 6.x, fixed in 7): under `trailingSlash: 'always'` a
+// *dynamic* endpoint whose name has a file extension matches only WITH a
+// trailing slash locally, while the static build (and production) serve it
+// without one. In `astro dev`, use /api/eips/{id}.json/ .
+//
+// The per-EIP counterpart of `/api/eips.json`: the same record, but a single
+// small fetch instead of the whole dataset — for the common "what about EIP
+// X?" question. Record shape is identical to the per-EIP source files in
+// `src/data/eips/`.
+export const prerender = true;
+
+export async function getStaticPaths() {
+  return eipsData.map((eip) => ({ params: { id: String(eip.id) } }));
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const eip = eipById.get(Number(params.id));
+  if (!eip) {
+    return new Response('Not found', { status: 404 });
+  }
+  return new Response(JSON.stringify(eip, null, 2), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/eips/[id].json.ts
+++ b/src/pages/api/eips/[id].json.ts
@@ -1,13 +1,13 @@
 import type { APIRoute } from 'astro';
-import { eipById, eipsData } from '../../../data/eips';
+import type { EIP } from '../../../types/eip';
+import { eipsData } from '../../../data/eips';
 
 // Emitted as one static artifact per EIP during `astro build`, served at
 // https://forkcast.org/api/eips/{id}.json.
 //
-// Dev-server quirk (Astro 6.x, fixed in 7): under `trailingSlash: 'always'` a
-// *dynamic* endpoint whose name has a file extension matches only WITH a
-// trailing slash locally, while the static build (and production) serve it
-// without one. In `astro dev`, use /api/eips/{id}.json/ .
+// Under `trailingSlash: 'always'` the dev server matches this route only WITH
+// a trailing slash, while the static build serves the bare file. In
+// `astro dev`, use /api/eips/{id}.json/ .
 //
 // The per-EIP counterpart of `/api/eips.json`: the same record, but a single
 // small fetch instead of the whole dataset — for the common "what about EIP
@@ -16,15 +16,10 @@ import { eipById, eipsData } from '../../../data/eips';
 export const prerender = true;
 
 export async function getStaticPaths() {
-  return eipsData.map((eip) => ({ params: { id: String(eip.id) } }));
+  return eipsData.map((eip) => ({ params: { id: String(eip.id) }, props: { eip } }));
 }
 
-export const GET: APIRoute = ({ params }) => {
-  const eip = eipById.get(Number(params.id));
-  if (!eip) {
-    return new Response('Not found', { status: 404 });
-  }
-  return new Response(JSON.stringify(eip, null, 2), {
+export const GET: APIRoute<{ eip: EIP }> = ({ props }) =>
+  new Response(JSON.stringify(props.eip, null, 2), {
     headers: { 'Content-Type': 'application/json' },
   });
-};

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -303,6 +303,21 @@ describe('build output', () => {
       expect(eip?.forkRelationships?.length).toBeGreaterThan(0);
     });
 
+    it('api/eips/{id}.json exists for every EIP and matches its source file', () => {
+      // llms.txt documents this path with a `{id}` placeholder, so the
+      // "points at paths that exist" check below cannot see it.
+      const dir = path.resolve(DIST, '..', 'src', 'data', 'eips');
+      const sources = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+      expect(fs.readdirSync(path.join(DIST, 'api/eips')).length).toBe(sources.length);
+      for (const file of sources) {
+        const built = path.join(DIST, 'api/eips', file);
+        expect(fs.existsSync(built), `missing /api/eips/${file}`).toBe(true);
+        expect(JSON.parse(fs.readFileSync(built, 'utf-8'))).toEqual(
+          JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8')),
+        );
+      }
+    });
+
     it('api/upgrades.json leaks no UI-only fields', () => {
       // `NetworkUpgrade` mixes protocol facts with render state. "The Merge:
       // disabled" is meaningless outside the upgrades page, so the endpoint


### PR DESCRIPTION
Prerenders one JSON file per EIP from the same compiled dataset as /api/eips.json, so single-EIP questions ('what about EIP X?') cost a 2-5 KB fetch instead of the ~580 KB bulk index.

Also documents the endpoint in llms.txt and points the single-EIP rows of the quick reference table at it.

Note: the local Astro dev server has a "bug" (fixed in Astro 7) where pages that have a file extension require a slash at the end of the URL. When building the site, the per EIP JSONs are created. ~I'll confirm the PR works in the branch deployment before asking for review.~ This is not an issue in production since netlify serves static files